### PR TITLE
[PIP-16] Expose ingress through LoadBalancer type service

### DIFF
--- a/stable/pipeline-cluster-ingress/values.yaml
+++ b/stable/pipeline-cluster-ingress/values.yaml
@@ -3,10 +3,8 @@
 # Declare variables to be passed into your templates.
 
 traefik:
-  serviceType: NodePort
-  service:
-    nodePorts: 
-      http: 30080
+  serviceType: LoadBalancer
+  loadBalancerIP:
 
   dashboard:
     enabled: true


### PR DESCRIPTION
Services running inside of Kubernetes cluster (e.g. Zeppelin, Spark RSS) can be made accessible from outside of the cluster using Ingress which needs to be accessible through a public IP. Expose ingress on a public IP in cloud environment via a service of type Loadbancer for Ingress controller.