### PR TITLE
Vault indentation fix

### DIFF
--- a/stable/vault/Chart.yaml
+++ b/stable/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.5.0
-appVersion: 0.10.0
+version: 0.5.1
+appVersion: 0.10.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/stable/vault/templates/configmap.yaml
+++ b/stable/vault/templates/configmap.yaml
@@ -13,6 +13,6 @@ data:
     {{ .Values.vault.config | toJson }}
     {{ else }}
     {{ (merge .Values.vault.config .Values.vault.defaultStorage) | toJson }}
-    {{ end -}}
+    {{ end }}
   vault-config.yml: |
     {{ .Values.vault.externalConfig | toJson }}

--- a/stable/vault/values.yaml
+++ b/stable/vault/values.yaml
@@ -123,7 +123,7 @@ unsealer:
       "--mode",
       "k8s",
       "--k8s-secret-namespace",
-      "vault",
+      "default",
       "--k8s-secret-name",
       "bank-vaults"
   ]

--- a/stable/vault/values.yaml
+++ b/stable/vault/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: vault
-  tag: 0.10.0
+  tag: 0.10.1
   pullPolicy: Always
 service:
   name: vault

--- a/stable/vault/values.yaml
+++ b/stable/vault/values.yaml
@@ -117,13 +117,13 @@ vault:
 unsealer:
   image:
     repository: banzaicloud/bank-vaults
-    tag: 0.1.0
+    tag: latest
     pullPolicy: Always
   args: [
       "--mode",
       "k8s",
       "--k8s-secret-namespace",
-      "default",
+      "vault",
       "--k8s-secret-name",
       "bank-vaults"
   ]


### PR DESCRIPTION
The vault-configurer fix @lpuskas 
The ConfigMap yaml file had an indentation issue, thus only one file got created.

Pipeline needs to use 0.5.1 after this one got merged.