### PR TITLE
Builder image, strict chart builds, individual chart fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: banzaicloud/helm-aws-s3
+      - image: banzaicloud/helm
         environment:
           AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
           AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,21 @@ jobs:
                 mkdir -p /tmp/s3-chart/stable
 
                 echo "Dependency update and build"
-                find . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -exec helm dependency update {} \; -exec helm dependency build {} \;
+                if [ $i == 3 ]; then
+                    for chart in $(find -H . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -print)
+                    do
+                        helm dependency update $chart
+                        helm dependency build $chart
+                    done
+                else
+                    find -H . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -exec helm dependency update {} \; -exec helm dependency build {} \;
+                fi
 
                 echo "Remove requirements.lock files"
-                find . -maxdepth 3 -name requirements.lock -type f -delete -print
+                find -H . -maxdepth 3 -name requirements.lock -type f -delete -print
 
                 echo "Create helm packages"
-                find . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -print -exec helm package -d /tmp/s3-chart/stable {} \;
+                find -H . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -print -exec helm package -d /tmp/s3-chart/stable {} \;
 
                 helm repo index --url $BANZAICLOUD_STABLE_REPO /tmp/s3-chart/stable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+RUN apk add --update ca-certificates git openssl py-pip
+
+RUN pip install --upgrade pip && pip install s3cmd
+
+RUN wget -O - https://raw.githubusercontent.com/kubernetes/helm/v2.9.1/scripts/get | sh

--- a/efs-provisioner/Chart.yaml
+++ b/efs-provisioner/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: EFS Provisioner
+name: efs-provisioner
+version: 0.0.1
+home: https://github.com/banzaicloud/banzai-charts

--- a/kubeless/requirements.yaml
+++ b/kubeless/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: kafka
-  version: 0.1
+  version: 0.3.0
   repository: alias:banzaicloud-stable

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -32,6 +32,6 @@ dependencies:
   condition: telescopes.enabled
 
 - name: productinfo
-  version: 0.1.2
+  version: 0.1.1
   repository: alias:banzaicloud-stable
   condition: productinfo.enabled

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -32,6 +32,6 @@ dependencies:
   condition: telescopes.enabled
 
 - name: productinfo
-  version: 0.1.1
+  version: 0.1.2
   repository: alias:banzaicloud-stable
   condition: productinfo.enabled

--- a/sonarqube/requirements.yaml
+++ b/sonarqube/requirements.yaml
@@ -1,5 +1,4 @@
 dependencies:
   - name: postgresql
-    version: 0.*.*
-    repository: file://../postgresql
-
+    version: "*"
+    repository: "alias:stable"


### PR DESCRIPTION
- This PR adds the Dockerfile for a chart builder image used in CircleCI.
- Also enables strict run in the last iteration step of chart building. (Sometimes chart builds could fail silently end we ended up with missing charts from the main repository).
- This previous strict mode revealed a few errors in the current charts scheme.

Fixes: #254 