### PR TITLE
Custom TLS certificate on Pipeline's internal API + Chart Build Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
 
             echo "REPO -> STABLE"
 
-            #TODO: Dirty hack to solve multi level dependency
-            for i in $(seq 1 3);
+            #TODO: Dirty hack to solve multi level dependency, the current dependency depth is 4
+            for i in $(seq 1 4);
             do
 
                 helm repo add banzaicloud-stable ${BANZAICLOUD_STABLE_REPO} || true
@@ -47,7 +47,7 @@ jobs:
                 mkdir -p /tmp/s3-chart/stable
 
                 echo "Dependency update and build"
-                if [ $i == 3 ]; then
+                if [ $i == 4 ]; then
                     for chart in $(find -H . -maxdepth 1 ! -path /tmp  ! -path . ! -path ./.circleci ! -path ./.git -type d -print)
                     do
                         helm dependency update $chart

--- a/drone/Chart.yaml
+++ b/drone/Chart.yaml
@@ -1,6 +1,6 @@
 name: drone
 home: https://drone.io/
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.8.5
 description: Drone CI
 keywords:

--- a/drone/templates/deployment-server.yaml
+++ b/drone/templates/deployment-server.yaml
@@ -69,7 +69,7 @@ spec:
             value: /build
 
           - name: PIPELINE_BASE_URL
-            value: http://{{ .Release.Name }}-pipeline.{{ .Release.Namespace }}:9090{{ .Values.global.pipelineBasepath }}
+            value: https://{{ .Release.Name }}-pipeline.{{ .Release.Namespace }}:9090{{ .Values.global.pipelineBasepath }}
 
         volumeMounts:
         - mountPath: /var/lib/drone

--- a/pipeline-cluster-ingress/Chart.yaml
+++ b/pipeline-cluster-ingress/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: pipeline-cluster-ingress
-version: 0.0.1
+version: 0.0.2
 keywords:
   - pipeline
   - cluster

--- a/pipeline-cluster-ingress/requirements.yaml
+++ b/pipeline-cluster-ingress/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: traefik
-  version: 1.14.2
+  version: 1.34.0
   repository: https://kubernetes-charts.storage.googleapis.com/
 
 

--- a/pipeline-cluster-ingress/values.yaml
+++ b/pipeline-cluster-ingress/values.yaml
@@ -12,3 +12,5 @@ traefik:
   rbac:
     enabled: true
 
+  ssl:
+    insecureSkipVerify: true

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
   condition: prometheus.enabled
 
 - name: pipeline
-  version: 0.0.7
+  version: 0.0.8
   repository: alias:banzaicloud-stable
 
 - name: pipeline-ui

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -23,7 +23,7 @@ dependencies:
   condition: pipeline-ui.enabled
 
 - name: drone
-  version: 0.1.4
+  version: 0.1.5
   repository: alias:banzaicloud-stable
 
 - name: telescopes

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: grafana.enabled
 
 - name: traefik
-  version: 1.24.1
+  version: 1.34.0
   repository: https://kubernetes-charts.storage.googleapis.com/
 
 - name: prometheus

--- a/pipeline-cp/templates/pipeline-ingress.yaml
+++ b/pipeline-cp/templates/pipeline-ingress.yaml
@@ -16,7 +16,7 @@ spec:
           - path: /
             backend:
              serviceName: {{ .Release.Name }}-pipeline
-             servicePort: 443
+             servicePort: 9090
       {{- if .Values.pipeline.host }}
       host: {{ .Values.pipeline.host }}
       {{- end }}

--- a/pipeline-cp/templates/pipeline-ingress.yaml
+++ b/pipeline-cp/templates/pipeline-ingress.yaml
@@ -16,7 +16,7 @@ spec:
           - path: /
             backend:
              serviceName: {{ .Release.Name }}-pipeline
-             servicePort: 9090
+             servicePort: 443
       {{- if .Values.pipeline.host }}
       host: {{ .Values.pipeline.host }}
       {{- end }}

--- a/pipeline-cp/values.yaml
+++ b/pipeline-cp/values.yaml
@@ -13,6 +13,8 @@ traefik:
   memoryLimit: 250Mi
   debug:
     enabled: false
+  ssl:
+    insecureSkipVerify: true
 
 pipeline:
   host: ""

--- a/pipeline/Chart.yaml
+++ b/pipeline/Chart.yaml
@@ -2,7 +2,7 @@ name: pipeline
 home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/charts/
-version: 0.0.7
+version: 0.0.8
 description: A Helm chart for Kubernetes
 keywords:
   - pipeline

--- a/pipeline/templates/deployment.yaml
+++ b/pipeline/templates/deployment.yaml
@@ -175,19 +175,23 @@ spec:
           value: /vault/tls/ca.crt
 
         - name: PIPELINE_PIPELINE_CERTFILE
-          value: /pipeline/tls/server.crt
+          value: /tls/server.crt
         - name: PIPELINE_PIPELINE_KEYFILE
-          value: /pipeline/tls/server.key
+          value: /tls/server.key
 
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: {{ .Values.global.pipelineBasepath }}/api
             port: {{ .Values.service.internalPort }}
+            scheme: HTTPS
           initialDelaySeconds: 15
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: {{ .Values.global.pipelineBasepath }}/api
             port: {{ .Values.service.internalPort }}
+            scheme: HTTPS
           initialDelaySeconds: 10
 
         resources:
@@ -207,7 +211,7 @@ spec:
           mountPath: /vault/tls
 
         - name: pipeline-tls
-          mountPath: /pipeline/tls
+          mountPath: /tls
 
       volumes:
       - name: gke-credential

--- a/pipeline/templates/deployment.yaml
+++ b/pipeline/templates/deployment.yaml
@@ -174,6 +174,11 @@ spec:
         - name: VAULT_CACERT
           value: /vault/tls/ca.crt
 
+        - name: PIPELINE_PIPELINE_CERTFILE
+          value: /pipeline/tls/server.crt
+        - name: PIPELINE_PIPELINE_KEYFILE
+          value: /pipeline/tls/server.key
+
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
@@ -201,6 +206,9 @@ spec:
         - name: vault-tls
           mountPath: /vault/tls
 
+        - name: pipeline-tls
+          mountPath: /pipeline/tls
+
       volumes:
       - name: gke-credential
         secret:
@@ -219,5 +227,8 @@ spec:
       - name: vault-tls
         secret:
           secretName: "{{ .Release.Name }}-vault-tls"
+      - name: pipeline-tls
+        secret:
+          secretName: "{{ template "fullname" . }}-tls"
 
       serviceAccountName: pipeline

--- a/pipeline/templates/secrets.yaml
+++ b/pipeline/templates/secrets.yaml
@@ -35,6 +35,8 @@ data:
   gke-credential.json:
     {{ printf "{ \"client_id\": \"%s\", \"client_secret\": \"%s\", \"refresh_token\": \"%s\", \"type\": \"%s\" }" .Values.gkeCredentials.client_id .Values.gkeCredentials.client_secret .Values.gkeCredentials.refresh_token .Values.gkeCredentials.type | b64enc }}
 
+---
+
 {{- $cn := include "fullname" . -}}
 {{- $externalDNS := print $cn "." .Release.Namespace -}}
 {{- $ca := genCA "pipeline-ca" 365 -}}

--- a/pipeline/templates/secrets.yaml
+++ b/pipeline/templates/secrets.yaml
@@ -34,3 +34,22 @@ type: Opaque
 data:
   gke-credential.json:
     {{ printf "{ \"client_id\": \"%s\", \"client_secret\": \"%s\", \"refresh_token\": \"%s\", \"type\": \"%s\" }" .Values.gkeCredentials.client_id .Values.gkeCredentials.client_secret .Values.gkeCredentials.refresh_token .Values.gkeCredentials.type | b64enc }}
+
+{{- $cn := include "fullname" . -}}
+{{- $externalDNS := print $cn "." .Release.Namespace -}}
+{{- $ca := genCA "pipeline-ca" 365 -}}
+{{- $cert := genSignedCert $cn (list "127.0.0.1") (list $cn $externalDNS) 365 $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-tls
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  ca.key: {{ $ca.Key | b64enc }}
+  server.crt: {{ $cert.Cert | b64enc }}
+  server.key: {{ $cert.Key | b64enc }}

--- a/pipeline/templates/service.yaml
+++ b/pipeline/templates/service.yaml
@@ -14,9 +14,5 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
     name: {{ .Values.service.name }}
-  - port: 443
-    targetPort: {{ .Values.service.internalPort }}
-    protocol: TCP
-    name: {{ .Values.service.name }}-https
   selector:
     app: {{ template "fullname" . }}

--- a/pipeline/templates/service.yaml
+++ b/pipeline/templates/service.yaml
@@ -14,5 +14,9 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
     name: {{ .Values.service.name }}
+  - port: 443
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}-https
   selector:
     app: {{ template "fullname" . }}

--- a/pipeline/templates/service.yaml
+++ b/pipeline/templates/service.yaml
@@ -14,5 +14,9 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
     name: {{ .Values.service.name }}
+  - port: 443
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}-tls
   selector:
     app: {{ template "fullname" . }}


### PR DESCRIPTION
- This PR also contains a build fix (we have dependency depth level 4, instead of 3: kubeless -> kafka -> etcd -> etcd-operator)
- Traefik upgrade to support self signed cert backends
- Pipeline TLS certificate generated by Helm
- Drone change to call Pipeline on HTTPS