### PR TITLE
Drone agents need to run in a proper serviceAccount in RBAC enabled clusters

### DIFF
--- a/drone/Chart.yaml
+++ b/drone/Chart.yaml
@@ -1,6 +1,6 @@
 name: drone
 home: https://drone.io/
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.8.5
 description: Drone CI
 keywords:
@@ -11,6 +11,7 @@ keywords:
 - drone
 - drone.io
 - go
+- kubernetes
 sources:
 - https://github.com/drone/drone
 maintainers:

--- a/drone/templates/clusterrole.yaml
+++ b/drone/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "drone.fullname" . }}-agent
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "drone.fullname" . }}-agent-rbac"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "drone.fullname" . }}-agent
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/drone/templates/deployment-agent.yaml
+++ b/drone/templates/deployment-agent.yaml
@@ -17,8 +17,9 @@ spec:
         release: "{{ .Release.Name }}"
         component: agent
     spec:
+      serviceAccount: {{ template "drone.fullname" . }}-agent
       containers:
-      - name: {{ template "drone.fullname" . }}-agent
+      - name: drone-agent
         image: "{{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag }}"
         command: ["/bin/drone-agent"]
         imagePullPolicy: {{ .Values.agentImage.pullPolicy }}

--- a/drone/templates/deployment-server.yaml
+++ b/drone/templates/deployment-server.yaml
@@ -25,7 +25,7 @@ spec:
         command: ["/cloud_sql_proxy",
                   "-instances={{ .Values.cloudsql.instance }}=tcp:3306"]
       {{- end }}
-      - name: {{ template "drone.fullname" . }}-server
+      - name: drone-server
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["/bin/drone-server"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -23,7 +23,7 @@ dependencies:
   condition: pipeline-ui.enabled
 
 - name: drone
-  version: 0.1.5
+  version: 0.1.6
   repository: alias:banzaicloud-stable
 
 - name: telescopes

--- a/pipeline/templates/clusterrolebinding.yaml
+++ b/pipeline/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: pipeline
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-admin


### PR DESCRIPTION
Otherwise, namespaces and pods can't be created with drone-agent in the CP cluster in bootstrap steps.