### PR TITLE
Chart.yaml name fix

### DIFF
--- a/logging-operator/Chart.yaml
+++ b/logging-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Logging operator helm chart
-name: logging operator
-version: 0.0.1
+name: logging-operator
+version: 0.0.2
 appVersion: 0.0.1
 home: https://github.com/banzaicloud/logging-operator


### PR DESCRIPTION
Directory name (logging-operator) and Chart.yaml name (logging operator) must match