### PR TITLE
PIPELINE_AUTH_SECURECOOKIE should be always true in Helm deployments

### DIFF
--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   condition: prometheus.enabled
 
 - name: pipeline
-  version: 0.0.16
+  version: 0.0.17
   repository: alias:banzaicloud-stable
 
 - name: pipeline-ui

--- a/pipeline/Chart.yaml
+++ b/pipeline/Chart.yaml
@@ -2,7 +2,7 @@ name: pipeline
 home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/charts/
-version: 0.0.16
+version: 0.0.17
 description: A Helm chart for Kubernetes
 keywords:
   - pipeline

--- a/pipeline/templates/deployment.yaml
+++ b/pipeline/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
           value: {{ .Values.auth.jwtaudience | quote }}
         - name: PIPELINE_AUTH_COOKIEDOMAIN
           value: {{ .Values.auth.cookieDomain | quote }}
+        - name: PIPELINE_AUTH_SECURECOOKIE
+          value: "true"
 
         - name: PIPELINE_DRONE_URL
           value: http://{{ .Release.Name }}-drone:80


### PR DESCRIPTION
We always use TLS in Helm, so it should be true by default