### PR TITLE
specify DRONE_EXTERNAL_URL

### DIFF
--- a/drone/Chart.yaml
+++ b/drone/Chart.yaml
@@ -1,6 +1,6 @@
 name: drone
 home: https://drone.io/
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.8.5
 description: Drone CI
 keywords:

--- a/drone/templates/deployment-server.yaml
+++ b/drone/templates/deployment-server.yaml
@@ -65,8 +65,10 @@ spec:
         {{- else if .Values.cloudsql.enabled }}
             value: {{ .Values.cloudsql.dbUserName }}:{{ .Values.cloudsql.dbUserPass }}@tcp(127.0.0.1:3306)/drone?parseTime=true
         {{- end }}
-          - name: DRONE_BASEPATH
-            value: /build
+        {{- if hasKey .Values.ingress "hosts" }}
+          - name: DRONE_EXTERNAL_URL
+            value: https://{{ index .Values.ingress.hosts 0 }}
+        {{- end }}
 
           - name: PIPELINE_BASE_URL
             value: https://{{ .Release.Name }}-pipeline.{{ .Release.Namespace }}:9090{{ .Values.global.pipelineBasepath }}

--- a/pipeline-cp/Chart.yaml
+++ b/pipeline-cp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: pipeline-cp
-version: 0.2.10
+version: 0.2.11
 keywords:
     - pipeline
     - controlplane

--- a/pipeline-cp/requirements.yaml
+++ b/pipeline-cp/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   condition: pipeline-ui.enabled
 
 - name: drone
-  version: 0.2.1
+  version: 0.2.2
   repository: alias:banzaicloud-stable
   condition: drone.enabled
 


### PR DESCRIPTION
This is needed so Drone hooks are registered to the external Ingress address.