### PR TITLE
traefic: fix yaml if .Values.metrics.prometheus.service.annotations e…

### DIFF
--- a/traefik/templates/metrics-prometheus-service.yaml
+++ b/traefik/templates/metrics-prometheus-service.yaml
@@ -12,7 +12,9 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"
     prometheus.io/port: {{ .Values.metrics.prometheus.service.port | quote }}
-{{ toYaml .Values.metrics.prometheus.service.annotations | indent 4 }}
+    {{- if .Values.metrics.prometheus.service.annotations }}
+    {{ toYaml .Values.metrics.prometheus.service.annotations | indent 4 }}
+    {{- end }}
 spec:
   selector:
     app: {{ template "traefik.name" . }}


### PR DESCRIPTION
…mpty

this broke pipeline cluster creation
YAML parse error on pipeline-cluster-ingress/charts/traefik/templates/metrics-prometheus-service.yaml: error converting YAML to JSON: yaml: line 15: could not find expected ':'