### PR TITLE
Replace builtin SSL redirection with manual one

### DIFF
--- a/pipeline-cluster-monitor/Chart.yaml
+++ b/pipeline-cluster-monitor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: pipeline-cluster-monitor
-version: 0.1.8
+version: 0.1.9
 keywords:
   - pipeline
   - cluster

--- a/pipeline-cluster-monitor/values.yaml
+++ b/pipeline-cluster-monitor/values.yaml
@@ -305,7 +305,9 @@ grafana:
     annotations: 
       kubernetes.io/ingress.class: traefik
       traefik.frontend.rule.type: PathPrefixStrip
-      traefik.ingress.kubernetes.io/ssl-redirect: "true"
+      traefik.ingress.kubernetes.io/redirect-permanent: "true"
+      traefik.ingress.kubernetes.io/redirect-regex: ^http://(.*)
+      traefik.ingress.kubernetes.io/redirect-replacement: https://$1
     path: /grafana
     hosts:
       - localhost


### PR DESCRIPTION
As outlined in [this](https://github.com/containous/traefik/issues/1957)
issue SSL redirection with PathPrefixStrip does not work really well.

A solution was provided in [this](https://github.com/containous/traefik/pull/3631) PR,
released in 1.7, but it didn't really solve the issue.

In fact, there were several subsequent issues opened (https://github.com/containous/traefik/issues/3999, https://github.com/containous/traefik/issues/3876) but they got closed.

Another issue was opened in the Traefik repo: https://github.com/containous/traefik/issues/4085

Until then this workaround provides the same functionality.

Fixes #413