### PR TITLE
Extend security scanlog

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: anchore-policy-validator
-version: 0.2.0
-appVersion: 0.0.5
+version: 0.2.1
+appVersion: 0.1.0
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/templates/audit-crd.yaml
+++ b/anchore-policy-validator/templates/audit-crd.yaml
@@ -28,7 +28,16 @@ spec:
             image:
               type: array
               items:
-                type: string
+                type: object
+                properties:
+                  imageName:
+                    type: string
+                  imageTag:
+                    type: string
+                  imageDigest:
+                    type: string
+                  lastUpdated:
+                    type: string
             result:
               type: array
               items:
@@ -46,7 +55,7 @@ spec:
     priority: 1
   - name: Image
     type: string
-    JSONPath: .spec.image
+    JSONPath: .spec.image[*].imageName
     priority: 2
   - name: result
     type: string

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,7 +5,7 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.0.5
+  tag: 0.1.0
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck


### PR DESCRIPTION
- Use new anchore-image-validator 0.1.0
- Extend audit-log CRD
requirements: https://github.com/banzaicloud/anchore-image-validator/pull/21
prerequisite to https://github.com/banzaicloud/pipeline/pull/1356
prerequisite to https://github.com/banzaicloud/pipeline/issues/1334
prerequisite to https://github.com/banzaicloud/pipeline/issues/1348