### PR TITLE
Bump anchore-image-validator version

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: anchore-policy-validator
-version: 0.2.4
-appVersion: 0.1.2
+version: 0.2.5
+appVersion: 0.2.0
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,7 +5,7 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.1.2
+  tag: 0.2.0
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck


### PR DESCRIPTION
Merge after anchore-image-validator is tagged to 0.2.0
- [x]  banzaicloud/anchore-image-validator:0.2.0 