### PR TITLE
ValidatingWebhookConfiguration is created by image-validator

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: anchore-policy-validator
-version: 0.2.5
-appVersion: 0.2.0
+version: 0.3.0
+appVersion: 0.3.0
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/templates/apiservice-webhook.yaml
+++ b/anchore-policy-validator/templates/apiservice-webhook.yaml
@@ -30,34 +30,3 @@ items:
       name: {{ template "anchore-policy-validator.fullname" . }}
       namespace: {{ .Release.Namespace }}
     version: {{ .Values.apiService.version }}
-
-- apiVersion: admissionregistration.k8s.io/v1beta1
-  kind: ValidatingWebhookConfiguration
-  metadata:
-    name: {{ template "anchore-policy-validator.fullname" . }}.admission.anchore.io
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "5"
-  webhooks:
-  - name: {{ template "anchore-policy-validator.fullname" . }}.admission.anchore.io
-    clientConfig:
-      service:
-        namespace: default
-        name: kubernetes
-        path: /apis/{{ .Values.apiService.group }}/v1beta1/imagechecks
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-    - operations:
-      - CREATE
-      apiGroups:
-      - ""
-      apiVersions:
-      - "*"
-      resources:
-      - pods
-    failurePolicy: Fail
-    namespaceSelector:
-      matchExpressions:
-        - key: scan
-          operator: NotIn
-          values: [noscan]

--- a/anchore-policy-validator/templates/validator-deployment.yaml
+++ b/anchore-policy-validator/templates/validator-deployment.yaml
@@ -33,6 +33,14 @@ spec:
           - "--tls-private-key-file=/var/serving-cert/servingKey"
           - "--v={{ .Values.logVerbosity }}"
           env:
+          - name: KUBERNETES_NAMESPACE
+            value: {{ .Release.Namespace }}
+          - name: ANCHORE_APISERVICE_GROUP
+            value: {{ .Values.apiService.group }}
+          - name: ANCHORE_APISERVICE_VERSION
+            value: {{ .Values.apiService.version }}
+          - name: ANCHORE_RELEASE_NAME
+            value: {{ template "anchore-policy-validator.name" . }}
           - name: ANCHORE_ENGINE_USERNAME
             value: {{ .Values.externalAnchore.anchoreUser }}
           - name: ANCHORE_ENGINE_PASSWORD

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,7 +5,7 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.2.0
+  tag: 0.3.0
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck


### PR DESCRIPTION
- Remove ValidatingWebhokConfiguration from chart
- Bump anchore-image-validator version

requirements: https://github.com/banzaicloud/anchore-image-validator/pull/30
merge after tag https://github.com/banzaicloud/anchore-image-validator to 0.3.0
