### PR TITLE
fix typo: env var OPERATOR_NAMESAPCE in deployment

### DIFF
--- a/vault-operator/templates/deployment.yaml
+++ b/vault-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           command:
             - vault-operator
           env:
-            - name: OPERATOR_NAMESAPCE
+            - name: OPERATOR_NAMESPACE
               value: {{ .Values.watchNamespace }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}


### PR DESCRIPTION
fix typo: env var OPERATOR_NAMESAPCE in deployment

This was messing up the namespace being passed around.