### PR TITLE
Add helm crd-install hook to vault-operator crd

### DIFF
--- a/vault-operator/templates/crd.yaml
+++ b/vault-operator/templates/crd.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ include "vault-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: vault.banzaicloud.com
   names:


### PR DESCRIPTION
Add helm crd hook to vault-operator crd, so that a crd is made ready before other resources.
Also,
When helm release being updated it is possible, that hook resource already exists in cluster. By default helm will try to create resource and fail with "... already exists" error. So adding hook-delete-policy to before-creation.