### PR TITLE
vault-secrets-webhook: mutate pods only

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.0"
+appVersion: "0.3.27"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.1.2
+version: 0.2.0
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -36,12 +36,12 @@ items:
   metadata:
     name: {{ template "vault-secrets-webhook.fullname" . }}
   webhooks:
-  - name: deployments.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
     clientConfig:
       service:
         namespace: {{ .Release.Namespace }}
         name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /deployments
+        path: /pods
       caBundle: {{ b64enc $ca.Cert }}
     rules:
     - operations:
@@ -51,39 +51,5 @@ items:
       apiVersions:
       - "*"
       resources:
-      - deployments
-    failurePolicy: Fail
-  - name: replicasets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-    clientConfig:
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /replicasets
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-    - operations:
-      - CREATE
-      apiGroups:
-      - "*"
-      apiVersions:
-      - "*"
-      resources:
-      - replicasets
-    failurePolicy: Fail
-  - name: statefulsets.{{ template "vault-secrets-webhook.name" . }}.{{ .Values.apiService.group }}
-    clientConfig:
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /statefulsets
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-    - operations:
-      - CREATE
-      apiGroups:
-      - "*"
-      apiVersions:
-      - "*"
-      resources:
-      - statefulsets
+      - pods
     failurePolicy: Fail


### PR DESCRIPTION
In relation with: https://github.com/banzaicloud/bank-vaults/pull/255

Fixes: https://github.com/banzaicloud/bank-vaults/issues/254