### PR TITLE
Bump image to 0.4.2, support for affinity

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.3.6"
+appVersion: "0.4.2"
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.1.1
+version: 0.2.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/templates/deployment.yaml
+++ b/vault-operator/templates/deployment.yaml
@@ -29,8 +29,12 @@ spec:
           command:
             - vault-operator
           env:
-            - name: OPERATOR_NAMESPACE
+            - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
@@ -50,5 +54,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
       serviceAccount: {{ include "vault-operator.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/vault-operator/values.yaml
+++ b/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.3.6
+  tag: 0.4.2
   pullPolicy: IfNotPresent
 
 service:
@@ -28,6 +28,8 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+affinity: {}
 
 terminationGracePeriodSeconds: 10
 


### PR DESCRIPTION
- Add POD_NAME env variable, it is required by newer versions of
vault operator
- Rename OPERATOR_NAMESPACE to WATCH_NAMESPACE
- Add support for affinity.