### PR TITLE
vault-secrets-webhook: secret type not needed

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.27"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.0
+version: 0.3.1
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -11,7 +11,6 @@ items:
   kind: Secret
   metadata:
     name: {{ template "vault-secrets-webhook.fullname" . }}
-    type: kubernetes.io/tls
   data:
     servingCert: {{ b64enc $server.Cert }}
     servingKey: {{ b64enc $server.Key }}


### PR DESCRIPTION
Fixes: #628 