### PR TITLE
vault-secrets-webhook: upgrade deployment if secrets (certs) change

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.27"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: {{ template "vault-secrets-webhook.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/apiservice-webhook.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "vault-secrets-webhook.fullname" . }}
       volumes:


### PR DESCRIPTION
Fixes: https://github.com/banzaicloud/bank-vaults/issues/305