### PR TITLE
pipeline: add pipelineExternalBaseURL setting

### DIFF
--- a/pipeline/Chart.yaml
+++ b/pipeline/Chart.yaml
@@ -3,7 +3,7 @@ home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/pipeline/
   - https://github.com/banzaicloud/banzai-charts/
-version: 0.1.5
+version: 0.1.6
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline

--- a/pipeline/templates/deployment.yaml
+++ b/pipeline/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
 
         - name: PIPELINE_PIPELINE_BASEPATH
           value: {{ .Values.global.pipelineBasepath | quote }}
+        - name: PIPELINE_PIPELINE_EXTERNALURL
+          value: {{ .Values.pipelineExternalBaseURL | quote }}
         - name: PIPELINE_PIPELINE_SIGNUPREDIRECTPATH
           value: {{ .Values.signupredirectpath | quote }}
 

--- a/pipeline/values.yaml
+++ b/pipeline/values.yaml
@@ -8,6 +8,7 @@ global:
     clientsecret: ""
   pipelineBasepath: /pipeline
 
+pipelineExternalBaseURL: https://example.org/pipeline
 signupredirectpath: /ui/
 
 github:


### PR DESCRIPTION
this is now used by Pipeline to pass in the generated bootstrap commands
for PKE node(pool)s

see banzaicloud/pipeline#1674