### PR TITLE
Fix ordering of default in case of tokenSigningKey

### DIFF
--- a/pipeline/templates/secrets.yaml
+++ b/pipeline/templates/secrets.yaml
@@ -11,7 +11,7 @@ type: Opaque
 data:
   githubClientId: {{ default .Values.auth.clientid .Values.global.auth.clientid | b64enc | quote }}
   githubClientSecret: {{ default .Values.auth.clientsecret .Values.global.auth.clientsecret | b64enc | quote }}
-  tokenSigningKey: {{ default .Values.auth.tokenSigningKey .Values.global.auth.clientsecret | b64enc | quote }}
+  tokenSigningKey: {{ default .Values.global.auth.clientsecret .Values.auth.tokenSigningKey | b64enc | quote }}
   githubToken: {{ .Values.github.token | b64enc | quote }}
 
 ---


### PR DESCRIPTION
If `tokenSigningKey` is defined it should take precedence.