### PR TITLE
Update anchore-engine version to v0.3.2

### DIFF
--- a/anchore-engine/Chart.yaml
+++ b/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 name: anchore-engine
-version: 0.2.7
-appVersion: 0.3.0
+version: 0.2.8
+appVersion: 0.3.2
 description: Anchore container analysis and policy evaluation engine service
 keywords:
  - analysis

--- a/anchore-engine/templates/core-deployment.yaml
+++ b/anchore-engine/templates/core-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       app: "{{ template "anchore-engine.name" . }}"
       component: "anchore-core"
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
   template:
@@ -22,7 +21,6 @@ spec:
       labels:
         app: "{{ template "anchore-engine.name" . }}"
         component: "anchore-core"
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:

--- a/anchore-engine/templates/service.yaml
+++ b/anchore-engine/templates/service.yaml
@@ -34,6 +34,5 @@ spec:
   selector:
       app: "{{ template "anchore-engine.name" . }}"
       component: "anchore-core"
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"

--- a/anchore-engine/templates/worker-deployment.yaml
+++ b/anchore-engine/templates/worker-deployment.yaml
@@ -16,12 +16,10 @@ spec:
       release: "{{ .Release.Name }}"
       app: "{{ template "anchore-engine.name" . }}"
       heritage: "{{ .Release.Service }}"
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:
         app: "{{ template "anchore-engine.name" . }}"
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         component: "anchore-worker"

--- a/anchore-engine/values.yaml
+++ b/anchore-engine/values.yaml
@@ -13,7 +13,7 @@ service:
 image:
   # Can use 'latest' but not recommended
   repository: "docker.io/anchore/anchore-engine"
-  tag: "v0.3.0"
+  tag: "v0.3.2"
   pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
- update anchore-engine version to v0.3.2 (contains db reconnectiont fix)
- remove chart label from pod templates (remaining old pods fix)
fixes: #609 