### PR TITLE
vault-operator: add syncPeriod flag + separate readinessProbe from livenessProbe

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.7"
+appVersion: "0.4.8"
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.5
+version: 0.2.6
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/templates/deployment.yaml
+++ b/vault-operator/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - vault-operator
+            - -sync_period
+            - {{ .Values.syncPeriod }}
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace }}

--- a/vault-operator/templates/deployment.yaml
+++ b/vault-operator/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.probePath }}/ready
               port: {{ .Values.service.internalPort }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/vault-operator/values.yaml
+++ b/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.4.7
+  tag: 0.4.8
   pullPolicy: IfNotPresent
 
 service:
@@ -22,6 +22,7 @@ crdAnnotations: {}
 # The namespace where the operator watches for vault CRD objects, if not defined
 # all namespaces are watched
 watchNamespace: ""
+syncPeriod: "1m"
 
 resources:
   limits:


### PR DESCRIPTION
Needs to release bank-vaults 0.4.8 first.

Fixes: https://github.com/banzaicloud/bank-vaults/issues/320