### PR TITLE
thanos - fix the data-dir value to actually use the empty volume

### DIFF
--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         {{- end }}
         args:
         - "store"
+        - "--data-dir=/var/thanos/store"
         - "--log.level={{ .Values.store.logLevel }}"
         - "--grpc-address=0.0.0.0:{{ .Values.store.grpc.port }}"
         - "--cluster.address={{ .Values.cluster.address }}:{{ .Values.cluster.port}}"


### PR DESCRIPTION
The default value of the `--data-dir` argument is `./data`:

```
 --data-dir="./data"        Data directory in which to cache remote blocks.
```

Therefore, the folder actually being used is `/data` not `/var/thanos/store`

This PR fixes this behaviour