### PR TITLE
Use unprivileged internalPort in policy-validator

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.3.4
-appVersion: 0.3.1
+version: 0.3.5
+appVersion: 0.3.2
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/templates/validator-deployment.yaml
+++ b/anchore-policy-validator/templates/validator-deployment.yaml
@@ -32,6 +32,7 @@ spec:
           - "--tls-cert-file=/var/serving-cert/servingCert"
           - "--tls-private-key-file=/var/serving-cert/servingKey"
           - "--v={{ .Values.logVerbosity }}"
+          - "--secure-port={{ .Values.service.internalPort }}"
           env:
           - name: KUBERNETES_NAMESPACE
             value: {{ .Release.Namespace }}
@@ -47,6 +48,9 @@ spec:
             value: {{ .Values.externalAnchore.anchorePass }}
           - name: ANCHORE_ENGINE_URL
             value: {{ .Values.externalAnchore.anchoreHost }}
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,13 +5,13 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.3.1
+  tag: 0.3.2
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck
   type: ClusterIP
   externalPort: 443
-  internalPort: 443
+  internalPort: 8443
 externalAnchore:
   anchoreHost: ""
   anchoreUser: ""


### PR DESCRIPTION
requirements: https://github.com/banzaicloud/anchore-image-validator/pull/33
Merge it after banzaicloud/anchore-image-validator tag 0.3.2 is built succesfully.