### PR TITLE
Vault-secrets-webhook use unprivileged internalPort

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.11"
+appVersion: "0.4.12"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.5
+version: 0.3.6
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -48,6 +48,9 @@ spec:
           volumeMounts:
           - mountPath: /var/serving-cert
             name: serving-cert
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- if .Values.nodeSelector }}

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -8,14 +8,14 @@ debug: false
 
 image:
   repository: banzaicloud/vault-secrets-webhook
-  tag: 0.4.11
+  tag: 0.4.12
   pullPolicy: IfNotPresent
 
 service:
   name: vault-secrets-webhook
   type: ClusterIP
   externalPort: 443
-  internalPort: 443
+  internalPort: 8443
 
 env:
   VAULT_IMAGE: vault:latest


### PR DESCRIPTION
requirements: https://github.com/banzaicloud/bank-vaults/pull/350
Merge after banzaicloud/vault-secrets-webhook tag 0.4.12 is built succesfully