### PR TITLE
Limit RBAC permissions of vault webhook

### DIFF
--- a/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -5,13 +5,33 @@ metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - "create"
+      - "update"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}-limited
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: cluster-admin
+  name: {{ template "vault-secrets-webhook.fullname" . }}
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
PR for https://github.com/banzaicloud/bank-vaults/issues/375

The vault webhook rbac permissions are currently set to `cluster-admin` which gives the webhook more permissions than it actually needs.

The PR limits the permissions to `"get"` for secrets and configmaps and `"create"`, `"update"`  for configmaps which should represent its current usage.

Fixes: https://github.com/banzaicloud/bank-vaults/issues/375