### PR TITLE
Add ingress resource to  vault-operator clusterrole

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.8"
+appVersion: "0.4.14"
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.7
+version: 0.2.8
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/templates/role.yaml
+++ b/vault-operator/templates/role.yaml
@@ -44,3 +44,11 @@ rules:
   - etcdclusters
   verbs:
   - "*"
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - create
+    - update


### PR DESCRIPTION
- fix missing ingress resource in clusterrole
- use newer vault-operator image (0.4.14)

fixes: #727 