### PR TITLE
circleci: update image to avoid using circleci's native git client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: banzaicloud/helm:0.0.3
+      - image: banzaicloud/helm:0.0.4
 
     steps:
       - checkout
@@ -23,7 +23,7 @@ jobs:
 
   build-and-publish-single-chart:
     docker:
-      - image: banzaicloud/helm:0.0.3
+      - image: banzaicloud/helm:0.0.4
 
     working_directory: /workspace/banzai-charts
 


### PR DESCRIPTION
CircleCi uses its own git client when `git` or `openssh` is missing.
The problem is that it cannot checkout annotated tags.