### PR TITLE
vault: remove as many ClusterRoles as possible and reduce RBAC scopes

### DIFF
--- a/vault-operator/templates/role.yaml
+++ b/vault-operator/templates/role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "vault-operator.fullname" . }}
   labels:
@@ -16,9 +16,6 @@ rules:
   resources:
   - pods
   - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
   - configmaps
   - secrets
   verbs:
@@ -33,8 +30,6 @@ rules:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
   - statefulsets
   verbs:
   - "*"

--- a/vault-operator/templates/rolebinding.yaml
+++ b/vault-operator/templates/rolebinding.yaml
@@ -12,16 +12,3 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vault-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "vault-operator.fullname" . }}-auth-delegator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- kind: ServiceAccount
-  name: {{ include "vault-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}

--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.1.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/vault/templates/role.yaml
+++ b/vault/templates/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-secret-access
   labels:

--- a/vault/templates/rolebinding.yaml
+++ b/vault/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ kind: List
 metadata: {}
 items:
 - apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
+  kind: RoleBinding
   metadata:
     name: {{ template "vault.fullname" . }}-auth-delegator
     labels:
@@ -20,7 +20,7 @@ items:
     name: {{ template "vault.fullname" . }}
     namespace: {{ .Release.Namespace }}
 - apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
+  kind: RoleBinding
   metadata:
     name: {{ template "vault.fullname" . }}-secret-access
     labels:
@@ -29,7 +29,7 @@ items:
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
   roleRef:
-    kind: ClusterRole
+    kind: Role
     name: {{ template "vault.fullname" . }}-secret-access
     apiGroup: rbac.authorization.k8s.io
   subjects:


### PR DESCRIPTION
Remove unnecessary RBAC roled bindings from Vault chart.