### PR TITLE
dex: add the capability to run the dex example-app

### DIFF
--- a/dex/Chart.yaml
+++ b/dex/Chart.yaml
@@ -1,6 +1,6 @@
 name: dex
-version: 0.0.10
-appVersion: master
+version: 0.0.11
+appVersion: 0.3.2
 description: dexidp Dex
 keywords:
 - dex

--- a/dex/templates/config.yaml
+++ b/dex/templates/config.yaml
@@ -22,11 +22,13 @@ data:
         database: {{ .Values.postgresql.postgresqlDatabase }}
         user: {{ .Values.postgresql.postgresqlUsername }}
         password: {{ .Values.postgresql.postgresqlPassword }}
-        {{- else }}
+        {{- else if .Values.cloudsql.enabled }}
         host: {{ default "localhost:5432" .Values.config.storage.config.host }}
         database: {{ .Values.config.storage.config.database }}
         user: {{ .Values.config.storage.config.user }}
         password: {{ .Values.config.storage.config.password }}
+        {{- else }}
+{{ toYaml .Values.config.storage.config | indent 8 }}
         {{- end }}
         ssl:
           mode: {{ default "disable" .Values.config.storage.config.ssl.mode }}

--- a/dex/templates/deployment.yaml
+++ b/dex/templates/deployment.yaml
@@ -40,6 +40,25 @@ spec:
           runAsUser: 2
           allowPrivilegeEscalation: false
       {{- end }}
+      {{- if .Values.exampleApp.enabled  }}
+      - name: example-app
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+        - /usr/local/bin/example-app
+        - --client-id {{ .Values.exampleApp.clientID }}
+        - --client-secret {{ .Values.exampleApp.clientSecret }}
+        - --issuer {{ .Values.config.issuer }}
+        - --redirect-uri {{ .Values.exampleApp.redirectURI }}
+        - --listen http://0.0.0.0:5555
+        securityContext:
+          runAsUser: 2
+          allowPrivilegeEscalation: false
+        ports:
+        - name: example-app
+          containerPort: 5555
+          protocol: TCP
+      {{- end }}
       - name: dex-server
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/dex/templates/service.yaml
+++ b/dex/templates/service.yaml
@@ -15,6 +15,11 @@ spec:
   type: {{ .Values.service.type}}
   sessionAffinity: None
   ports:
+{{- if .Values.exampleApp.enabled  }}
+  - name: example-app
+    port: 5555
+    targetPort: 5555
+{{- end}}
 {{- range .Values.ports }}
   - name: {{ .name }} 
     port: {{ .containerPort }}

--- a/dex/values.yaml
+++ b/dex/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 image: banzaicloud/dex-shim
-imageTag: "master"
+imageTag: "0.3.2"
 imagePullPolicy: "IfNotPresent"
 
 replicas: 1
@@ -22,6 +22,12 @@ cloudsql:
     tag: 1.11
     pullPolicy: IfNotPresent
   instance: ""
+
+exampleApp:
+  enabled: false
+  clientID: ""
+  clientSecret: ""
+  redirectURI: ""
 
 # resources:
   # limits:


### PR DESCRIPTION
The intention here is to be able to execute a full web-flow with Dex without installing any other application outside of this chart.