### PR TITLE
vault: add regular envs

### DIFF
--- a/vault/templates/statefulset.yaml
+++ b/vault/templates/statefulset.yaml
@@ -48,6 +48,10 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
+        {{- range .Values.vault.envs }}
+        - name: {{ .name }}
+          value: {{ .value}}
+        {{- end }}
         volumeMounts:
         - name: vault-raw-config
           mountPath: /vault/raw-config/
@@ -59,16 +63,20 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["vault", "server", "-config", "/vault/config/config.json"]
         env:
-          - name: VAULT_CACERT
-            value: /vault/tls/ca.crt
-          - name: VAULT_LOG_LEVEL
-            value: {{ .Values.vault.logLevel }}
-          - name: VAULT_ADDR
-          {{ if .Values.vault.config.listener.tcp.tls_disable }}
-            value: http://127.0.0.1:{{ .Values.service.port }}
-           {{ else }}
-            value: https://127.0.0.1:{{ .Values.service.port }}
-           {{ end }}
+        - name: VAULT_CACERT
+          value: /vault/tls/ca.crt
+        - name: VAULT_LOG_LEVEL
+          value: {{ .Values.vault.logLevel }}
+        - name: VAULT_ADDR
+        {{ if .Values.vault.config.listener.tcp.tls_disable }}
+          value: http://127.0.0.1:{{ .Values.service.port }}
+          {{ else }}
+          value: https://127.0.0.1:{{ .Values.service.port }}
+          {{ end }}
+        {{- range .Values.vault.envs }}
+        - name: {{ .name }}
+          value: {{ .value}}
+        {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
         - secretRef:
@@ -127,21 +135,25 @@ spec:
         command: ["bank-vaults", "unseal", "--init"]
         args: {{ toJson .Values.unsealer.args }}
         env:
-          - name: VAULT_CACERT
-            value: /vault/tls/ca.crt
-          - name: VAULT_ADDR
-          {{ if .Values.vault.config.listener.tcp.tls_disable }}
-            value: http://127.0.0.1:{{ .Values.service.port }}
-           {{ else }}
-            value: https://127.0.0.1:{{ .Values.service.port }}
-           {{ end }}
-          {{- range .Values.vault.envSecrets }}
-          - name: {{ .envName }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ .secretName }}
-                key: {{ .secretKey }}
-          {{- end }}
+        - name: VAULT_CACERT
+          value: /vault/tls/ca.crt
+        - name: VAULT_ADDR
+        {{ if .Values.vault.config.listener.tcp.tls_disable }}
+          value: http://127.0.0.1:{{ .Values.service.port }}
+          {{ else }}
+          value: https://127.0.0.1:{{ .Values.service.port }}
+          {{ end }}
+        {{- range .Values.vault.envSecrets }}
+        - name: {{ .envName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName }}
+              key: {{ .secretKey }}
+        {{- end }}
+        {{- range .Values.vault.envs }}
+        - name: {{ .name }}
+          value: {{ .value}}
+        {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
         - secretRef:
@@ -165,21 +177,25 @@ spec:
         command: ["bank-vaults", "configure"]
         args: {{ toJson .Values.unsealer.args }}
         env:
-          - name: VAULT_CACERT
-            value: /vault/tls/ca.crt
-          - name: VAULT_ADDR
-          {{ if .Values.vault.config.listener.tcp.tls_disable }}
-            value: http://127.0.0.1:{{ .Values.service.port }}
-           {{ else }}
-            value: https://127.0.0.1:{{ .Values.service.port }}
-           {{ end }}
-          {{- range .Values.vault.envSecrets }}
-          - name: {{ .envName }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ .secretName }}
-                key: {{ .secretKey }}
-          {{- end }}
+        - name: VAULT_CACERT
+          value: /vault/tls/ca.crt
+        - name: VAULT_ADDR
+        {{ if .Values.vault.config.listener.tcp.tls_disable }}
+          value: http://127.0.0.1:{{ .Values.service.port }}
+          {{ else }}
+          value: https://127.0.0.1:{{ .Values.service.port }}
+          {{ end }}
+        {{- range .Values.vault.envSecrets }}
+        - name: {{ .envName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .secretName }}
+              key: {{ .secretKey }}
+        {{- end }}
+        {{- range .Values.vault.envs }}
+        - name: {{ .name }}
+          value: {{ .value}}
+        {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
         - secretRef:

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -77,6 +77,10 @@ vault:
     # - secretName: mysql
     #   secretKey: mysql-username
     #   envName: "MYSQL_USERNAME"
+  # Allows adding various custom eenvironment variables directly.
+  envs: []
+    # - name: GOOGLE_APPLICATION_CREDENTIALS
+    #   value: /etc/gcp/service-account.json
   externalConfig:
     # Allows creating policies in Vault which can be used later on in roles
     # for the Kubernetes based authentication.


### PR DESCRIPTION
Adding regular environment variables to chart makes possible to pass easily eg. `GOOGLE_APPLICATION_CREDENTIALS`. Without that GCP + KMS setup never worked for me resulting in:
```
time="2019-04-18T07:46:16Z" level=error msg="error unsealing vault: unable to get key 'vault-unseal-0': error getting object for key 'vault-unseal-0': storage: object doesn't exist"`.
```

Seem like Vault itself prefers also passing credentials with env:
```
2019-04-18T07:47:23.789Z [WARN]  storage.gcs: specifying credentials_file as an option is deprecated. Please use the GOOGLE_APPLICATION_CREDENTIALS environment variable or instance credentials instead.
```