### PR TITLE
feat(vault,vault-secrets-webhook): add podSecurityPolicy support

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.13"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.7
+version: 0.3.8
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -35,4 +35,5 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 |service.name                         |webhook service name                         |vault-secrets-webhook                     |
 |service.type                         |webhook service type                         |ClusterIP                                 |
 |tolerations                          |tolerations to add                           |[]                                        |
-|podSecurityPolicy.enabled            |use pod security policy                      |true                                      |
+|rabc.enabled                         |use rbac                                     |true                                      |
+|rabc.psp.enabled                     |use pod security policy                      |false                                     |

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -35,3 +35,4 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 |service.name                         |webhook service name                         |vault-secrets-webhook                     |
 |service.type                         |webhook service type                         |ClusterIP                                 |
 |tolerations                          |tolerations to add                           |[]                                        |
+|podSecurityPolicy.enabled            |use pod security policy                      |true                                      |

--- a/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -23,6 +23,16 @@ rules:
     verbs:
       - "create"
       - "update"
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - {{ template "vault-secrets-webhook.fullname" . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "vault-secrets-webhook.fullname" . }}
 ---
+{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,7 +24,7 @@ rules:
     verbs:
       - "create"
       - "update"
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if .Values.rbac.psp.enabled }}
   - apiGroups:
       - extensions
     resources:
@@ -46,3 +47,4 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ template "vault-secrets-webhook.fullname" . }}
+{{- end }}

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -29,5 +29,7 @@ tolerations: []
 
 affinity: {}
 
-podSecurityPolicy:
+rbac:
   enabled: true
+  psp:
+    enabled: false

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -28,3 +28,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityPolicy:
+  enabled: true

--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.1.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/vault/README.md
+++ b/vault/README.md
@@ -129,6 +129,7 @@ The following tables lists the configurable parameters of the vault chart and th
 | `resources.limits.cpu`  | Container requested CPU             | `nil`                                               |
 | `resources.limits.memory` | Container requested memory        | `nil`                                               |
 | `unsealer.args`         | Bank Vaults args | `["--mode", "k8s", "--k8s-secret-namespace", "default", "--k8s-secret-name", "bank-vaults"]` |
+| `podSecurityPolicy.enabled` | Use pod security policy         | `true`                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/vault/README.md
+++ b/vault/README.md
@@ -129,7 +129,8 @@ The following tables lists the configurable parameters of the vault chart and th
 | `resources.limits.cpu`  | Container requested CPU             | `nil`                                               |
 | `resources.limits.memory` | Container requested memory        | `nil`                                               |
 | `unsealer.args`         | Bank Vaults args | `["--mode", "k8s", "--k8s-secret-namespace", "default", "--k8s-secret-name", "bank-vaults"]` |
-| `podSecurityPolicy.enabled` | Use pod security policy         | `true`                                              |
+| `rabc.enabled`          | Use rbac                            | `true`                                              |
+| `rabc.psp.enabled`      | Use pod security policy             | `false`                                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/vault/templates/role.yaml
+++ b/vault/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -11,9 +12,10 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["*"]
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if .Values.rbac.psp.enabled }}
 - apiGroups: ["extensions"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
   resourceNames: [{{ template "vault.fullname" . }}]
+{{- end }}
 {{- end }}

--- a/vault/templates/role.yaml
+++ b/vault/templates/role.yaml
@@ -11,3 +11,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["*"]
+{{- if .Values.podSecurityPolicy.enabled }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames: [{{ template "vault-secrets-webhook.fullname" . }}]
+{{- end }}

--- a/vault/templates/role.yaml
+++ b/vault/templates/role.yaml
@@ -15,5 +15,5 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
-  resourceNames: [{{ template "vault-secrets-webhook.fullname" . }}]
+  resourceNames: [{{ template "vault.fullname" . }}]
 {{- end }}

--- a/vault/templates/rolebinding.yaml
+++ b/vault/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.enabled }}
 apiVersion: v1
 kind: List
 metadata: {}
@@ -36,3 +37,4 @@ items:
   - kind: ServiceAccount
     name: {{ template "vault.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -200,5 +200,7 @@ statsd:
         method: "$1"
         path: "$2"
 
-podSecurityPolicy:
+rbac:
   enabled: true
+  psp:
+    enabled: false

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -199,3 +199,6 @@ statsd:
       labels:
         method: "$1"
         path: "$2"
+
+podSecurityPolicy:
+  enabled: true


### PR DESCRIPTION
We add for vault charts configurable pod security policy support.
It's will be great if you can use it on all your charts.