### PR TITLE
dex: add readinessProbe

### DIFF
--- a/dex/Chart.yaml
+++ b/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.0.15
+version: 0.0.16
 appVersion: 0.3.4
 description: dexidp Dex
 keywords:

--- a/dex/templates/config.yaml
+++ b/dex/templates/config.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
 data:
   config.yaml: |-
-    issuer: {{ default "http://127.0.0.1:5556/dex" .Values.config.issuer }}
+    issuer: {{ .Values.config.issuer }}
     storage:
       {{- if or .Values.postgresql.enabled .Values.cloudsql.enabled }}
       type: postgres

--- a/dex/templates/deployment.yaml
+++ b/dex/templates/deployment.yaml
@@ -47,6 +47,13 @@ spec:
         - /usr/local/bin/dex
         - serve
         - /etc/dex/cfg/config.yaml
+        readinessProbe:
+          httpGet:
+            path: /{{ slice (splitList "/" .Values.config.issuer) 3 | join "/" }}/healthz
+            port: http
+            {{- if .Values.config.web.https }}
+            scheme: HTTPS
+            {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         ports:

--- a/dex/values.yaml
+++ b/dex/values.yaml
@@ -70,7 +70,7 @@ serviceAccount:
   name:
 
 config:
-  issuer: ""
+  issuer: "http://127.0.0.1:5556/dex"
 
   logger:
     level: ""


### PR DESCRIPTION
In certain environments, the readinessProbe is a mush like GKE ingress doesn't work otherwise, and also it is nice to have a proper readinessProbe but GKE pointed it out that the Dex chart lacks one.