### PR TITLE
Update RBAC of vault operator to match up-to-date requirements from bank-vaults repo

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.14"
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.9
+version: 0.2.10
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/templates/role.yaml
+++ b/vault-operator/templates/role.yaml
@@ -29,6 +29,12 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
   - deployments
   - statefulsets
   verbs:
@@ -36,7 +42,7 @@ rules:
 - apiGroups:
   - etcd.database.coreos.com
   resources:
-  - etcdclusters
+  - "*"
   verbs:
   - "*"
 - apiGroups:
@@ -44,6 +50,16 @@ rules:
   resources:
     - ingresses
   verbs:
+    - list
     - get
     - create
     - update
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+  verbs:
+    - update
+    - list
+    - get
+    - create


### PR DESCRIPTION

* change resources for etcd.database
* add requirement for https://github.com/banzaicloud/bank-vaults/pull/438
* add requirement for https://github.com/banzaicloud/bank-vaults/pull/440
* add missing "monitoring.coreos.com" section