### PR TITLE
watch is required for operator ingresses permissions

### DIFF
--- a/vault-operator/templates/role.yaml
+++ b/vault-operator/templates/role.yaml
@@ -54,6 +54,7 @@ rules:
     - get
     - create
     - update
+    - watch
 - apiGroups:
     - monitoring.coreos.com
   resources:


### PR DESCRIPTION
I had this spamming my logs on 0.4.15-rc.13 upgade, 

```
vault-operator 2019-05-02T23:13:10.54981417Z E0502 23:13:10.549486       1 reflector.go:251] pkg/mod/k8s.io/client-go@v0.0.0-20190115164855-701b91367003/tools/cache/reflector.go:95: Failed to watch *v1beta1.Ingress: unknown (get ingresses.extensions)
```