### PR TITLE
circleci/orb: change required tag format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
       - run:
           name: Check versions
           command: |
-            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $1}')"
-            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $2}')"
+            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $(NF-1)}')"
+            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $NF}')"
 
             if [ ! -d "/workspace/banzai-charts/${chart_name}" ]; then
                 echo "Chart does not exist; name='${chart_name}'"
@@ -61,8 +61,8 @@ jobs:
       - run:
           name: Build chart
           command: |
-            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $1}')"
-            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $2}')"
+            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $(NF-1)}')"
+            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $NF}')"
 
             mkdir -p "/workspace/tgz"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
 jobs:
   build:
     executor: helm/helm
+    resource_class: small
 
     steps:
       - checkout
@@ -24,6 +25,7 @@ jobs:
 
   publish-chart:
     executor: helm/helm
+    resource_class: small
 
     working_directory: /workspace/banzai-charts
 

--- a/.circleci/orb.yml
+++ b/.circleci/orb.yml
@@ -22,7 +22,7 @@ examples:
                   branches:
                     ignore: /.*/
                   tags:
-                    only: /logging-operator\/\d+.\d+.\d+/
+                    only: /chart\/logging-operator\/\d+.\d+.\d+/
   custom-repository:
     description: Release a helm chart using additional helm repositories
     usage:
@@ -43,7 +43,7 @@ examples:
                   branches:
                     ignore: /.*/
                   tags:
-                    only: /logging-operator\/\d+.\d+.\d+/
+                    only: /chart\/logging-operator\/\d+.\d+.\d+/
 
 executors:
   helm:
@@ -100,8 +100,8 @@ commands:
           command: |
             chart_path="${CIRCLE_WORKING_DIRECTORY//\~/$HOME}/<< parameters.chart-path >>"
 
-            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $1}')"
-            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $2}')"
+            chart_name="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $(NF-1)}')"
+            chart_version="$(echo "${CIRCLE_TAG}" | awk -F '/' '{print $NF}')"
 
             if [ ! -d "${chart_path}" ]; then
                 echo "Chart does not exist; name='${chart_name}'"


### PR DESCRIPTION
From now on, both `<chart_name>/<chart_version>` and `<prefix>/<chart_name>/<chart_version>`
will be allowed tag formats.