### PR TITLE
cadence: add prometheus configuration

### DIFF
--- a/cadence/README.md
+++ b/cadence/README.md
@@ -42,61 +42,69 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Kubeless chart and their default values.
 
-| Parameter                               | Description                                   | Default                                   |
-| ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
-| `server.image.pullPolicy`               | Server Container pull policy                  | `IfNotPresent`                            |
-| `server.image.repository`               | Image repository for cadence Server           | `ubercadence/server`                      |
-| `server.image.tag`                      | Image Tag for cadence Server                  | `0.5.2`                                   |
-| `server.logLevel`                       | Server Log level                              | `debug,info`                              |
-| `server.nameOverride`                   | Override name of app                          | ``                                        |
-| `server.fullnameOverride`               | Override full name of app                     | ``                                        |
-| `server.bindOnLocalHost`                | Server bind on local host                     | `false`                                   |
-| `server.cassandraVisibilityKeyspace`    | Cassandra Visibility Keyspace                 | `cadence`                                 |
-| `server.replicaCount`                   | Number of Server Replicas                     | `1`                                       |
-| `server.frontend.enabled`               | Enable server frontend service                | `true`                                    |
-| `server.frontend.bindOnIP`              | Server frontend bind IP                       | `0.0.0.0`                                 |
-| `server.frontend.service.type`          | Server frontend service type                  | `ClusterIP`                               |
-| `server.frontend.service.port`          | Server frontend service port                  | `7933`                                    |
-| `server.matching.enabled`               | Enable server matching service                | `true`                                    |
-| `server.matching.bindOnIP`              | Server matching bind IP                       | `0.0.0.0`                                 |
-| `server.matching.service.type`          | Server matching service type                  | `ClusterIP`                               |
-| `server.matching.service.port`          | Server matching service port                  | `7935`                                    |
-| `server.history.enabled`                | Enable server history service                 | `true`                                    |
-| `server.history.bindOnIP`               | Server history bind IP                        | `0.0.0.0`                                 |
-| `server.history.numHistoryShards`       | Server history shards number                  | `4`                                       |
-| `server.history.service.type`           | Server history service type                   | `ClusterIP`                               |
-| `server.history.service.port`           | Server history service port                   | `7934`                                    |
-| `server.worker.enabled`                 | Enable server worker service                  | `true`                                    |
-| `server.worker.bindOnIP`                | Server worker bind IP                         | `0.0.0.0`                                 |
-| `server.worker.service.type`            | Server worker service type                    | `ClusterIP`                               |
-| `server.worker.service.port`            | Server worker service port                    | `7939`                                    |
-| `server.resources`                      | Server CPU/Memory resource requests/limits    | `{}`                                      |
-| `server.nodeSelector`                   | Node labels for pod assignment                | `{}`                                      |
-| `server.tolerations`                    | Toleration labels for pod assignment          | `[]`                                      |
-| `server.affinity`                       | Affinity settings for pod assignment          | `{}`                                      |
-| `web.enabled`                           | Enable WebUI service                          | `true`                                    |
-| `web.replicaCount`                      | Number of WebUI service Replicas              | `1`                                       |
-| `web.image.pullPolicy`                  | WebUI service Container pull policy           | `IfNotPresent`                            |
-| `web.image.repository`                  | Image repository for cadence WebUI            | `ubercadence/web`                         |
-| `web.image.tag`                         | Image Tag for cadence WebUI                   | `3.1.2`                                   |
-| `web.cadenceTchannelPeers`              | Cadence TChannel Peers                        | `cadence:7933`                            |
-| `web.nameOverride`                      | Override name of app                          | ``                                        |
-| `web.fullnameOverride`                  | Override full name of app                     | ``                                        |
-| `web.service.type`                      | WebUI service type                            | `ClusterIP`                               |
-| `web.service.port`                      | WebUI service port                            | `80`                                      |
-| `web.ingress.enabled`                   | Enables WebUI Ingress                         | `false`                                   |
-| `web.ingress.annotations`               | WebUI Ingress annotations                     | `{}`                                      |
-| `web.ingress.hosts`                     | WebUI Ingress hosts                           | `/`                                       |
-| `web.ingress.tls`                       | WebUI Ingress tls config                      | `[]`                                      |
-| `web.resources`                         | WebUI CPU/Memory resource requests/limits     | `{}`                                      |
-| `web.nodeSelector`                      | Node labels for pod assignment                | `{}`                                      |
-| `web.tolerations`                       | Toleration labels for pod assignment          | `[]`                                      |
-| `web.affinity`                          | Affinity settings for pod assignment          | `{}`                                      |
-| `cassandra.enabled`                     | Enable Cassandra cluster install              | `true`                                    |
-| `cassandra.config.cluster_size`         | Cassandra cluster node number                 | `1`                                       |
-| `cassandra.seeds`                       | Cassandra Seeds                               | `cassandra`                               |
-| `cassandra.consistency`                 | Cassandra Consistency                         | `One`                                     |
-| `cassandra.keyspace`                    | Cassandra keyspace name                       | `cadence`                                 |
+| Parameter                              | Description                                | Default              |
+| -------------------------------------- | ------------------------------------------ | -------------------- |
+| `server.image.pullPolicy`              | Server Container pull policy               | `IfNotPresent`       |
+| `server.image.repository`              | Image repository for cadence Server        | `ubercadence/server` |
+| `server.image.tag`                     | Image Tag for cadence Server               | `0.5.2`              |
+| `server.logLevel`                      | Server Log level                           | `debug,info`         |
+| `server.nameOverride`                  | Override name of app                       | ``                   |
+| `server.fullnameOverride`              | Override full name of app                  | ``                   |
+| `server.bindOnLocalHost`               | Server bind on local host                  | `false`              |
+| `server.cassandraVisibilityKeyspace`   | Cassandra Visibility Keyspace              | `cadence`            |
+| `server.replicaCount`                  | Number of Server Replicas                  | `1`                  |
+| `server.frontend.enabled`              | Enable server frontend service             | `true`               |
+| `server.frontend.bindOnIP`             | Server frontend bind IP                    | `0.0.0.0`            |
+| `server.frontend.service.type`         | Server frontend service type               | `ClusterIP`          |
+| `server.frontend.service.port`         | Server frontend service port               | `7933`               |
+| `server.frontend.prometheus.timerType` | Prometheus frontend timer type             | `histogram`          |
+| `server.frontend.prometheus.port`      | Prometheus frontend scrape port            | `8000`               |
+| `server.matching.enabled`              | Enable server matching service             | `true`               |
+| `server.matching.bindOnIP`             | Server matching bind IP                    | `0.0.0.0`            |
+| `server.matching.service.type`         | Server matching service type               | `ClusterIP`          |
+| `server.matching.service.port`         | Server matching service port               | `7935`               |
+| `server.matching.prometheus.timerType` | Prometheus matching timer type             | `histogram`          |
+| `server.matching.prometheus.port`      | Prometheus matching scrape port            | `8000`               |
+| `server.history.enabled`               | Enable server history service              | `true`               |
+| `server.history.bindOnIP`              | Server history bind IP                     | `0.0.0.0`            |
+| `server.history.numHistoryShards`      | Server history shards number               | `4`                  |
+| `server.history.service.type`          | Server history service type                | `ClusterIP`          |
+| `server.history.service.port`          | Server history service port                | `7934`               |
+| `server.history.prometheus.timerType`  | Prometheus history timer type              | `histogram`          |
+| `server.history.prometheus.port`       | Prometheus history scrape port             | `8000`               |
+| `server.worker.enabled`                | Enable server worker service               | `true`               |
+| `server.worker.bindOnIP`               | Server worker bind IP                      | `0.0.0.0`            |
+| `server.worker.service.type`           | Server worker service type                 | `ClusterIP`          |
+| `server.worker.service.port`           | Server worker service port                 | `7939`               |
+| `server.worker.prometheus.timerType`   | Prometheus worker timer type               | `histogram`          |
+| `server.worker.prometheus.port`        | Prometheus worker scrape port              | `8000`               |
+| `server.resources`                     | Server CPU/Memory resource requests/limits | `{}`                 |
+| `server.nodeSelector`                  | Node labels for pod assignment             | `{}`                 |
+| `server.tolerations`                   | Toleration labels for pod assignment       | `[]`                 |
+| `server.affinity`                      | Affinity settings for pod assignment       | `{}`                 |
+| `web.enabled`                          | Enable WebUI service                       | `true`               |
+| `web.replicaCount`                     | Number of WebUI service Replicas           | `1`                  |
+| `web.image.pullPolicy`                 | WebUI service Container pull policy        | `IfNotPresent`       |
+| `web.image.repository`                 | Image repository for cadence WebUI         | `ubercadence/web`    |
+| `web.image.tag`                        | Image Tag for cadence WebUI                | `3.1.2`              |
+| `web.cadenceTchannelPeers`             | Cadence TChannel Peers                     | `cadence:7933`       |
+| `web.nameOverride`                     | Override name of app                       | ``                   |
+| `web.fullnameOverride`                 | Override full name of app                  | ``                   |
+| `web.service.type`                     | WebUI service type                         | `ClusterIP`          |
+| `web.service.port`                     | WebUI service port                         | `80`                 |
+| `web.ingress.enabled`                  | Enables WebUI Ingress                      | `false`              |
+| `web.ingress.annotations`              | WebUI Ingress annotations                  | `{}`                 |
+| `web.ingress.hosts`                    | WebUI Ingress hosts                        | `/`                  |
+| `web.ingress.tls`                      | WebUI Ingress tls config                   | `[]`                 |
+| `web.resources`                        | WebUI CPU/Memory resource requests/limits  | `{}`                 |
+| `web.nodeSelector`                     | Node labels for pod assignment             | `{}`                 |
+| `web.tolerations`                      | Toleration labels for pod assignment       | `[]`                 |
+| `web.affinity`                         | Affinity settings for pod assignment       | `{}`                 |
+| `cassandra.enabled`                    | Enable Cassandra cluster install           | `true`               |
+| `cassandra.config.cluster_size`        | Cassandra cluster node number              | `1`                  |
+| `cassandra.seeds`                      | Cassandra Seeds                            | `cassandra`          |
+| `cassandra.consistency`                | Cassandra Consistency                      | `One`                |
+| `cassandra.keyspace`                   | Cassandra keyspace name                    | `cadence`            |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -8,98 +8,98 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  docker_template.yaml: |-
+  docker_template_cassandra.yaml: |-
     log:
-        stdout: true
-        level: "${LOG_LEVEL}"
+      stdout: true
+      level: "${LOG_LEVEL}"
 
     persistence:
-        defaultStore: cass-default
-        visibilityStore: cass-visibility
-        numHistoryShards: ${NUM_HISTORY_SHARDS}
-        datastores:
-            cass-default:
-                cassandra:
-                    hosts: "${CASSANDRA_SEEDS}"
-                    keyspace: "${KEYSPACE}"
-                    consistency: "${CASSANDRA_CONSISTENCY}"
-            cass-visibility:
-                cassandra:
-                    hosts: "${CASSANDRA_SEEDS}"
-                    keyspace: "${VISIBILITY_KEYSPACE}"
-                    consistency: "${CASSANDRA_CONSISTENCY}"
+      defaultStore: cass-default
+      visibilityStore: cass-visibility
+      numHistoryShards: ${NUM_HISTORY_SHARDS}
+      datastores:
+        cass-default:
+          cassandra:
+            hosts: "${CASSANDRA_SEEDS}"
+            keyspace: "${KEYSPACE}"
+            consistency: "${CASSANDRA_CONSISTENCY}"
+        cass-visibility:
+          cassandra:
+            hosts: "${CASSANDRA_SEEDS}"
+            keyspace: "${VISIBILITY_KEYSPACE}"
+            consistency: "${CASSANDRA_CONSISTENCY}"
 
     ringpop:
-        name: cadence
-        bootstrapMode: hosts
-        bootstrapHosts: ${RINGPOP_SEEDS_JSON_ARRAY}
-        maxJoinDuration: 30s
+      name: cadence
+      bootstrapMode: hosts
+      bootstrapHosts: ${RINGPOP_SEEDS_JSON_ARRAY}
+      maxJoinDuration: 30s
 
     services:
-        frontend:
-            rpc:
-                port: {{ .Values.server.frontend.service.port }}
-                bindOnIP: {{ .Values.server.frontend.bindOnIP }}
-            metrics:
-                prometheus:
-                    timerType: {{ .Values.server.frontend.prometheus.timerType }}
-                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.frontend.prometheus.port }}
+      frontend:
+        rpc:
+          port: {{ .Values.server.frontend.service.port }}
+          bindOnIP: {{ .Values.server.frontend.bindOnIP }}
+        metrics:
+          prometheus:
+            timerType: {{ .Values.server.frontend.prometheus.timerType }}
+            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.frontend.prometheus.port }}
 
-        matching:
-            rpc:
-                port: {{ .Values.server.matching.service.port }}
-                bindOnIP: {{ .Values.server.matching.bindOnIP }}
-            metrics:
-                prometheus:
-                    timerType: {{ .Values.server.matching.prometheus.timerType }}
-                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.matching.prometheus.port }}
+      matching:
+        rpc:
+          port: {{ .Values.server.matching.service.port }}
+          bindOnIP: {{ .Values.server.matching.bindOnIP }}
+        metrics:
+          prometheus:
+            timerType: {{ .Values.server.matching.prometheus.timerType }}
+            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.matching.prometheus.port }}
 
-        history:
-            rpc:
-                port: {{ .Values.server.history.service.port }}
-                bindOnIP: {{ .Values.server.history.bindOnIP }}
-            metrics:
-                prometheus:
-                    timerType: {{ .Values.server.history.prometheus.timerType }}
-                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.history.prometheus.port }}
+      history:
+        rpc:
+          port: {{ .Values.server.history.service.port }}
+          bindOnIP: {{ .Values.server.history.bindOnIP }}
+        metrics:
+          prometheus:
+            timerType: {{ .Values.server.history.prometheus.timerType }}
+            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.history.prometheus.port }}
 
-        worker:
-            rpc:
-                port: {{ .Values.server.worker.service.port }}
-                bindOnIP: {{ .Values.server.worker.bindOnIP }}
-            metrics:
-                prometheus:
-                    timerType: {{ .Values.server.worker.prometheus.timerType }}
-                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.worker.prometheus.port }}
+      worker:
+        rpc:
+          port: {{ .Values.server.worker.service.port }}
+          bindOnIP: {{ .Values.server.worker.bindOnIP }}
+        metrics:
+          prometheus:
+            timerType: {{ .Values.server.worker.prometheus.timerType }}
+            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.worker.prometheus.port }}
 
     clustersInfo:
-        enableGlobalDomain: false
-        failoverVersionIncrement: 10
-        masterClusterName: "active"
-        currentClusterName: "active"
-        clusterInitialFailoverVersion:
-            active: 0
-        clusterAddress:
-            active:
-                rpcName: "cadence-frontend"
-                rpcAddress: "127.0.0.1:7933"
+      enableGlobalDomain: false
+      failoverVersionIncrement: 10
+      masterClusterName: "active"
+      currentClusterName: "active"
+      clusterInitialFailoverVersion:
+        active: 0
+      clusterAddress:
+        active:
+          rpcName: "cadence-frontend"
+          rpcAddress: "127.0.0.1:7933"
 
     dcRedirectionPolicy:
-        policy: "noop"
-        toDC: ""
+      policy: "noop"
+      toDC: ""
 
     archival:
-        enableArchival: true
-        blobstore:
-            storeDirectory: "/tmp/blobstore/"
-            defaultBucket:
-                name: "cadence-development"
-                owner: "cadence"
-                retentionDays: 10
-            customBuckets:
-                - name: "custom-bucket-1"
-                  owner: "custom-owner-1"
-                  retentionDays: 10
-                - name: "custom-bucket-2"
-                  owner: "custom-owner-2"
-                  retentionDays: 5
+      enableArchival: true
+      blobstore:
+        storeDirectory: "/tmp/blobstore/"
+        defaultBucket:
+          name: "cadence-development"
+          owner: "cadence"
+          retentionDays: 10
+        customBuckets:
+          - name: "custom-bucket-1"
+            owner: "custom-owner-1"
+            retentionDays: 10
+          - name: "custom-bucket-2"
+            owner: "custom-owner-2"
+            retentionDays: 5

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -41,6 +41,8 @@ data:
           port: {{ .Values.server.frontend.service.port }}
           bindOnIP: {{ .Values.server.frontend.bindOnIP }}
         metrics:
+          tags:
+            type: frontend
           prometheus:
             timerType: {{ .Values.server.frontend.prometheus.timerType }}
             listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.frontend.prometheus.port }}
@@ -50,6 +52,8 @@ data:
           port: {{ .Values.server.matching.service.port }}
           bindOnIP: {{ .Values.server.matching.bindOnIP }}
         metrics:
+          tags:
+            type: matching
           prometheus:
             timerType: {{ .Values.server.matching.prometheus.timerType }}
             listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.matching.prometheus.port }}
@@ -59,6 +63,8 @@ data:
           port: {{ .Values.server.history.service.port }}
           bindOnIP: {{ .Values.server.history.bindOnIP }}
         metrics:
+          tags:
+            type: history
           prometheus:
             timerType: {{ .Values.server.history.prometheus.timerType }}
             listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.history.prometheus.port }}
@@ -68,6 +74,8 @@ data:
           port: {{ .Values.server.worker.service.port }}
           bindOnIP: {{ .Values.server.worker.bindOnIP }}
         metrics:
+          tags:
+            type: worker
           prometheus:
             timerType: {{ .Values.server.worker.prometheus.timerType }}
             listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.worker.prometheus.port }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -40,21 +40,38 @@ data:
             rpc:
                 port: {{ .Values.server.frontend.service.port }}
                 bindOnIP: {{ .Values.server.frontend.bindOnIP }}
+            metrics:
+                prometheus:
+                    timerType: {{ .Values.server.frontend.prometheus.timerType }}
+                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.frontend.prometheus.port }}
 
         matching:
             rpc:
                 port: {{ .Values.server.matching.service.port }}
                 bindOnIP: {{ .Values.server.matching.bindOnIP }}
+            metrics:
+                prometheus:
+                    timerType: {{ .Values.server.matching.prometheus.timerType }}
+                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.matching.prometheus.port }}
 
         history:
             rpc:
                 port: {{ .Values.server.history.service.port }}
                 bindOnIP: {{ .Values.server.history.bindOnIP }}
+            metrics:
+                prometheus:
+                    timerType: {{ .Values.server.history.prometheus.timerType }}
+                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.history.prometheus.port }}
 
         worker:
             rpc:
                 port: {{ .Values.server.worker.service.port }}
                 bindOnIP: {{ .Values.server.worker.bindOnIP }}
+            metrics:
+                prometheus:
+                    timerType: {{ .Values.server.worker.prometheus.timerType }}
+                    listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.worker.prometheus.port }}
+
     clustersInfo:
         enableGlobalDomain: false
         failoverVersionIncrement: 10
@@ -86,5 +103,3 @@ data:
                 - name: "custom-bucket-2"
                   owner: "custom-owner-2"
                   retentionDays: 5
-
-

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -103,3 +103,6 @@ data:
           - name: "custom-bucket-2"
             owner: "custom-owner-2"
             retentionDays: 5
+    
+    publicClient:
+      hostPort: "127.0.0.1:{{ .Values.server.frontend.service.port }}"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+{{- if semverCompare "<= 0.5.5" .Values.server.image.tag }}
+  docker_template.yaml: |-
+{{- else }}
   docker_template_cassandra.yaml: |-
+{{- end }}
     log:
       stdout: true
       level: "${LOG_LEVEL}"

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/name: {{ include "cadence.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
+        # Prometheus: issue with multiple scrape ports on same pod:
+        # https://github.com/prometheus/prometheus/issues/3756
         prometheus.io/scrape: 'true'
     spec:
       initContainers:

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cadence.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        prometheus.io/scrape: 'true'
     spec:
 
       initContainers:
@@ -51,20 +53,32 @@ spec:
             - name: frontend
               containerPort: {{ .Values.server.frontend.service.port }}
               protocol: TCP
+            - name: metrics-front
+              containerPort: {{ .Values.server.frontend.prometheus.port }}
+              protocol: TCP
           {{- end }}
           {{- if .Values.server.matching.enabled }}
             - name: matching
               containerPort: {{ .Values.server.matching.service.port }}
+              protocol: TCP
+            - name: metrics-match
+              containerPort: {{ .Values.server.matching.prometheus.port }}
               protocol: TCP
           {{- end }}
           {{- if .Values.server.history.enabled }}
             - name: history
               containerPort: {{ .Values.server.history.service.port }}
               protocol: TCP
+            - name: metrics-history
+              containerPort: {{ .Values.server.history.prometheus.port }}
+              protocol: TCP
           {{- end }}
           {{- if .Values.server.worker.enabled }}
             - name: worker
               containerPort: {{ .Values.server.worker.service.port }}
+              protocol: TCP
+            - name: metrics-worker
+              containerPort: {{ .Values.server.worker.prometheus.port }}
               protocol: TCP
           {{- end }}
 

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -130,7 +130,7 @@ spec:
           mountPath: /cadence/config/docker_template_cassandra.yaml
           subPath: docker_template_cassandra.yaml
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.server.resources | nindent 12 }}
 
       volumes:
       - name: "{{ .Chart.Name }}-config"

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -18,10 +18,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cadence.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.server.annotations }}
       annotations:
-        # Prometheus: issue with multiple scrape ports on same pod:
-        # https://github.com/prometheus/prometheus/issues/3756
-        prometheus.io/scrape: 'true'
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       initContainers:
       - name: check-cassandra

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -126,9 +126,15 @@ spec:
             port: {{ .Values.server.worker.service.port }}
           {{- end }}
         volumeMounts:
+{{- if semverCompare "<= 0.5.5" .Values.server.image.tag }}
+        - name: "{{ .Chart.Name }}-config"
+          mountPath: /cadence/config/docker_template.yaml
+          subPath: docker_template.yaml
+{{- else }}
         - name: "{{ .Chart.Name }}-config"
           mountPath: /cadence/config/docker_template_cassandra.yaml
           subPath: docker_template_cassandra.yaml
+{{- end }}
         resources:
           {{- toYaml .Values.server.resources | nindent 12 }}
 

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -21,123 +21,119 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
-
       initContainers:
       - name: check-cassandra
         image: "cassandra:3"
         command: ['sh', '-c', 'until cqlsh {{ template "cassandra.fullname" . }} -e "describe cluster"; do echo waiting for cassandra; sleep 2; done;']
 
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-          env:
-          - name: LOG_LEVEL
-            value: "{{ .Values.server.logLevel }}"
-          - name: CASSANDRA_SEEDS
-            value: {{ template "cassandra.fullname" . }}
-          - name: KEYSPACE
-            value: "{{ .Values.cassandra.keyspace }}"
-          - name: VISIBILITY_KEYSPACE
-            value: "{{ .Values.cassandraVisibilityKeyspace }}"
-          - name: CASSANDRA_CONSISTENCY
-            value: "{{ .Values.cassandra.consistency }}"
-          - name: NUM_HISTORY_SHARDS
-            value: "{{ .Values.server.history.numHistoryShards }}"
-          - name: BIND_ON_LOCALHOST
-            value: "{{ .Values.server.bindOnLocalHost }}"
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+        env:
+        - name: LOG_LEVEL
+          value: "{{ .Values.server.logLevel }}"
+        - name: CASSANDRA_SEEDS
+          value: {{ template "cassandra.fullname" . }}
+        - name: KEYSPACE
+          value: "{{ .Values.cassandra.keyspace }}"
+        - name: VISIBILITY_KEYSPACE
+          value: "{{ .Values.cassandraVisibilityKeyspace }}"
+        - name: CASSANDRA_CONSISTENCY
+          value: "{{ .Values.cassandra.consistency }}"
+        - name: NUM_HISTORY_SHARDS
+          value: "{{ .Values.server.history.numHistoryShards }}"
+        - name: BIND_ON_LOCALHOST
+          value: "{{ .Values.server.bindOnLocalHost }}"
 
+        ports:
+        {{- if .Values.server.frontend.enabled }}
+          - name: frontend
+            containerPort: {{ .Values.server.frontend.service.port }}
+            protocol: TCP
+          - name: metrics-front
+            containerPort: {{ .Values.server.frontend.prometheus.port }}
+            protocol: TCP
+        {{- end }}
+        {{- if .Values.server.matching.enabled }}
+          - name: matching
+            containerPort: {{ .Values.server.matching.service.port }}
+            protocol: TCP
+          - name: metrics-match
+            containerPort: {{ .Values.server.matching.prometheus.port }}
+            protocol: TCP
+        {{- end }}
+        {{- if .Values.server.history.enabled }}
+          - name: history
+            containerPort: {{ .Values.server.history.service.port }}
+            protocol: TCP
+          - name: metrics-history
+            containerPort: {{ .Values.server.history.prometheus.port }}
+            protocol: TCP
+        {{- end }}
+        {{- if .Values.server.worker.enabled }}
+          - name: worker
+            containerPort: {{ .Values.server.worker.service.port }}
+            protocol: TCP
+          - name: metrics-worker
+            containerPort: {{ .Values.server.worker.prometheus.port }}
+            protocol: TCP
+        {{- end }}
 
-          ports:
+        livenessProbe:
           {{- if .Values.server.frontend.enabled }}
-            - name: frontend
-              containerPort: {{ .Values.server.frontend.service.port }}
-              protocol: TCP
-            - name: metrics-front
-              containerPort: {{ .Values.server.frontend.prometheus.port }}
-              protocol: TCP
+          initialDelaySeconds: 150
+          tcpSocket:
+            port: {{ .Values.server.frontend.service.port }}
           {{- end }}
           {{- if .Values.server.matching.enabled }}
-            - name: matching
-              containerPort: {{ .Values.server.matching.service.port }}
-              protocol: TCP
-            - name: metrics-match
-              containerPort: {{ .Values.server.matching.prometheus.port }}
-              protocol: TCP
+          initialDelaySeconds: 150
+          tcpSocket:
+            port: {{ .Values.server.matching.service.port }}
           {{- end }}
           {{- if .Values.server.history.enabled }}
-            - name: history
-              containerPort: {{ .Values.server.history.service.port }}
-              protocol: TCP
-            - name: metrics-history
-              containerPort: {{ .Values.server.history.prometheus.port }}
-              protocol: TCP
+          initialDelaySeconds: 150
+          tcpSocket:
+            port: {{ .Values.server.history.service.port }}
           {{- end }}
           {{- if .Values.server.worker.enabled }}
-            - name: worker
-              containerPort: {{ .Values.server.worker.service.port }}
-              protocol: TCP
-            - name: metrics-worker
-              containerPort: {{ .Values.server.worker.prometheus.port }}
-              protocol: TCP
+          initialDelaySeconds: 150
+          tcpSocket:
+            port: {{ .Values.server.worker.service.port }}
           {{- end }}
 
-          livenessProbe:
-            {{- if .Values.server.frontend.enabled }}
-            initialDelaySeconds: 150
-            tcpSocket:
-              port: {{ .Values.server.frontend.service.port }}
-            {{- end }}
-            {{- if .Values.server.matching.enabled }}
-            initialDelaySeconds: 150
-            tcpSocket:
-              port: {{ .Values.server.matching.service.port }}
-            {{- end }}
-            {{- if .Values.server.history.enabled }}
-            initialDelaySeconds: 150
-            tcpSocket:
-              port: {{ .Values.server.history.service.port }}
-            {{- end }}
-            {{- if .Values.server.worker.enabled }}
-            initialDelaySeconds: 150
-            tcpSocket:
-              port: {{ .Values.server.worker.service.port }}
-            {{- end }}
-
-          readinessProbe:
-            {{- if .Values.server.frontend.enabled }}
-            initialDelaySeconds: 50
-            tcpSocket:
-              port: {{ .Values.server.frontend.service.port }}
-            {{- end }}
-            {{- if .Values.server.matching.enabled }}
-            initialDelaySeconds: 50
-            tcpSocket:
-              port: {{ .Values.server.matching.service.port }}
-            {{- end }}
-            {{- if .Values.server.history.enabled }}
-            initialDelaySeconds: 50
-            tcpSocket:
-              port: {{ .Values.server.history.service.port }}
-            {{- end }}
-            {{- if .Values.server.worker.enabled }}
-            initialDelaySeconds: 50
-            tcpSocket:
-              port: {{ .Values.server.worker.service.port }}
-            {{- end }}
-          volumeMounts:
-          - name: "{{ .Chart.Name }}-config"
-            mountPath: /cadence/config/docker_template.yaml
-            subPath: docker_template.yaml
-
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+        readinessProbe:
+          {{- if .Values.server.frontend.enabled }}
+          initialDelaySeconds: 50
+          tcpSocket:
+            port: {{ .Values.server.frontend.service.port }}
+          {{- end }}
+          {{- if .Values.server.matching.enabled }}
+          initialDelaySeconds: 50
+          tcpSocket:
+            port: {{ .Values.server.matching.service.port }}
+          {{- end }}
+          {{- if .Values.server.history.enabled }}
+          initialDelaySeconds: 50
+          tcpSocket:
+            port: {{ .Values.server.history.service.port }}
+          {{- end }}
+          {{- if .Values.server.worker.enabled }}
+          initialDelaySeconds: 50
+          tcpSocket:
+            port: {{ .Values.server.worker.service.port }}
+          {{- end }}
+        volumeMounts:
+        - name: "{{ .Chart.Name }}-config"
+          mountPath: /cadence/config/docker_template_cassandra.yaml
+          subPath: docker_template_cassandra.yaml
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
 
       volumes:
       - name: "{{ .Chart.Name }}-config"
         configMap:
           name: {{ include "cadence.fullname" . }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cadence/templates/web-service.yaml
+++ b/cadence/templates/web-service.yaml
@@ -8,7 +8,14 @@ metadata:
     helm.sh/chart: {{ include "cadence.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.web.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
+{{- with .Values.web.service.loadBalancerIP }}
+  loadBalancerIP: {{.}}
+{{- end }}
   type: {{ .Values.web.service.type }}
   ports:
     - port: {{ .Values.web.service.port }}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -7,7 +7,7 @@ server:
 
   image:
     repository: ubercadence/server
-    tag: master
+    tag: 0.5.8
     pullPolicy: IfNotPresent
 
   logLevel: "debug,info"

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -92,6 +92,10 @@ server:
 
   affinity: {}
 
+  annotations: {}
+    # Annotation to enable Prometheus scrape functionality.
+    # prometheus.io/scrape: 'true'
+
 web:
   enabled: true
 

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -110,6 +110,8 @@ web:
   service:
     type: ClusterIP
     port: 80
+    annotations: {}
+    # loadBalancerIP:
 
   ingress:
     enabled: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -7,7 +7,7 @@ server:
 
   image:
     repository: ubercadence/server
-    tag: 0.5.2
+    tag: master
     pullPolicy: IfNotPresent
 
   logLevel: "debug,info"
@@ -26,6 +26,9 @@ server:
     service:
       type: ClusterIP
       port: 7933
+    prometheus:
+      timerType: "histogram"
+      port: 8000
 
   matching:
     enabled: true
@@ -33,6 +36,9 @@ server:
     service:
       type: ClusterIP
       port: 7935
+    prometheus:
+      timerType: "histogram"
+      port: 8001
 
   history:
     enabled: true
@@ -41,6 +47,9 @@ server:
     service:
       type: ClusterIP
       port: 7934
+    prometheus:
+      timerType: "histogram"
+      port: 8002
 
   worker:
     enabled: true
@@ -48,7 +57,9 @@ server:
     service:
       type: ClusterIP
       port: 7939
-
+    prometheus:
+      timerType: "histogram"
+      port: 8003
 
   ingress:
     enabled: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -159,3 +159,12 @@ cassandra:
   keyspace: cadence
   config:
     cluster_size: 1
+  resources: {}
+    # requests:
+    #   memory: 4Gi
+    #   cpu: 1
+    # limits:
+    #   cpu: 2
+  # podDisruptionBudget:
+  #   maxUnavailable: 1
+    # minAvailable: 1


### PR DESCRIPTION
Initial proposition to add Prometheus configuration for cadence. Support is now added on cadence master by this PR https://github.com/uber/cadence/pull/1770.

This chart depends on build from `master` on `cadence` repository. So we need to wait until there is actual release with `prometheus` support. But meantime comments are welcome since there might be several points of improvements around.