### PR TITLE
Added s3_endpoint keys to the s3-output chart 

### DIFF
--- a/s3-output/Chart.yaml
+++ b/s3-output/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: S3 output helper chart for logging operator
 name: s3-output
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.0.1
 maintainers:
 - name: Banzai Cloud

--- a/s3-output/templates/CustomResource.yaml
+++ b/s3-output/templates/CustomResource.yaml
@@ -46,6 +46,8 @@ spec:
           value: "{{ .Values.instanceProfileCredentials.port }}"
         {{ end }}
 
+        - name: s3_endpoint
+          value: "{{ .Values.endpoint }}"
         - name: s3_bucket
           value: "{{ .Values.bucketName }}"
         - name: s3_region

--- a/s3-output/values.yaml
+++ b/s3-output/values.yaml
@@ -1,3 +1,6 @@
+# S3 bucket endpoint URL exp: https://s3.amazonaws.com, https://s3.wasabisys.com, or http://minio-service.default.svc.cluster.local:9000
+endpoint: ""
+
 # S3 Bucket name exp: my-logging-01
 bucketName: ""
 


### PR DESCRIPTION
This is for PR #802, [logging-operator/issues/92](https://github.com/banzaicloud/logging-operator/issues/92), and [logging-operator/pull/93](https://github.com/banzaicloud/logging-operator/pull/93).

Please just close if not necessary.