### PR TITLE
vault-secret-webhook: add namespaceSelector variable

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.13"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.8
+version: 0.3.9
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -39,20 +39,21 @@ $ helm upgrade --namespace vswh --install vswh banzaicloud-stable/vault-secrets-
 
 The following tables lists configurable parameters of the vault-secrets-webhook chart and their default values.
 
-|               Parameter             |                Description                  |                  Default                 |
-| ----------------------------------- | ------------------------------------------- | -----------------------------------------|
-|affinity                             |affinities to use                            |{}                                        |
-|debug                                |debug logs for webhook                       |false                                     |
-|image.pullPolicy                     |image pull policy                            |IfNotPresent                              |
-|image.repository                     |image repo that contains the admission server|banzaicloud/vault-secrets-webhook         |
-|image.tag                            |image tag                                    |latest                                    |
-|nodeSelector                         |node selector to use                         |{}                                        |
-|replicaCount                         |number of replicas                           |1                                         |
-|resources                            |resources to request                         |{}                                        |
-|service.externalPort                 |webhook service external port                |443                                       |
-|service.internalPort                 |webhook service external port                |443                                       |
-|service.name                         |webhook service name                         |vault-secrets-webhook                     |
-|service.type                         |webhook service type                         |ClusterIP                                 |
-|tolerations                          |tolerations to add                           |[]                                        |
-|rabc.enabled                         |use rbac                                     |true                                      |
-|rabc.psp.enabled                     |use pod security policy                      |false                                     |
+|               Parameter             |                    Description                    |                  Default                 |
+| ----------------------------------- | ------------------------------------------------- | -----------------------------------------|
+|affinity                             |affinities to use                                  |{}                                        |
+|debug                                |debug logs for webhook                             |false                                     |
+|image.pullPolicy                     |image pull policy                                  |IfNotPresent                              |
+|image.repository                     |image repo that contains the admission server      |banzaicloud/vault-secrets-webhook         |
+|image.tag                            |image tag                                          |latest                                    |
+|namespaceSelector                    |namespace selector to use, will limit webhook scope|{}                                        |
+|nodeSelector                         |node selector to use                               |{}                                        |
+|replicaCount                         |number of replicas                                 |1                                         |
+|resources                            |resources to request                               |{}                                        |
+|service.externalPort                 |webhook service external port                      |443                                       |
+|service.internalPort                 |webhook service external port                      |443                                       |
+|service.name                         |webhook service name                               |vault-secrets-webhook                     |
+|service.type                         |webhook service type                               |ClusterIP                                 |
+|tolerations                          |tolerations to add                                 |[]                                        |
+|rabc.enabled                         |use rbac                                           |true                                      |
+|rabc.psp.enabled                     |use pod security policy                            |false                                     |

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -40,7 +40,14 @@ items:
       - pods
     failurePolicy: Fail
     namespaceSelector:
+    {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+    {{- end }}
       matchExpressions:
+      {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 6 }}
+      {{- end }}
       - key: name
         operator: NotIn
         values:

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -25,6 +25,8 @@ resources: {}
 
 nodeSelector: {}
 
+namespaceSelector: {}
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
Fixes #814 

There were multiple ways of doing this. I think that this is the one that guarantees better freedom to end users since it replicates the LabelSelector spec. 

It also preservers the "NotIn" selector required to avoid recurrency.

I'm obviously open for discussion.

