### PR TITLE
Bump vault-operator to 0.4.15

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.14"
+appVersion: 0.4.15
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.11
+version: 0.2.12
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/values.yaml
+++ b/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.4.14
+  tag: 0.4.15
   pullPolicy: IfNotPresent
 
 service:

--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.13"
+appVersion: 0.4.15
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.10
+version: 0.3.11
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -8,7 +8,7 @@ debug: false
 
 image:
   repository: banzaicloud/vault-secrets-webhook
-  tag: 0.4.12
+  tag: 0.4.15
   pullPolicy: IfNotPresent
 
 service:

--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.6
-appVersion: 1.1.0
+version: 0.6.7
+appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -6,7 +6,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: vault
-  tag: 1.1.0
+  tag: 1.1.2
   pullPolicy: IfNotPresent
 service:
   name: vault
@@ -161,7 +161,7 @@ vault:
 unsealer:
   image:
     repository: banzaicloud/bank-vaults
-    tag: 0.4.14
+    tag: 0.4.15
     pullPolicy: IfNotPresent
   args: [
       "--mode",


### PR DESCRIPTION
Bump vault-operator to 0.4.15 for all Vault related charts. Also, update Vault to 1.1.2 for vault chart.