### PR TITLE
Allow vault-operator to watch servicemonitors

### DIFF
--- a/vault-operator/Chart.yaml
+++ b/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.4.15
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.12
+version: 0.2.13
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/vault-operator/templates/role.yaml
+++ b/vault-operator/templates/role.yaml
@@ -64,3 +64,4 @@ rules:
     - list
     - get
     - create
+    - watch


### PR DESCRIPTION
Otherwise, vault-operator will not be able to proceed with setting up the servicemonitor.