### PR TITLE
cadence: use the same cassandra image for deployment and check

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.5.2
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -22,7 +22,8 @@ spec:
 
       initContainers:
       - name: check-cassandra
-        image: "cassandra:3"
+        image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
+        imagePullPolicy: {{ .Values.cassandra.image.pullPolicy | quote }}
         command: ['sh', '-c', 'until cqlsh {{ template "cassandra.fullname" . }} -e "describe cluster"; do echo waiting for cassandra; sleep 2; done;']
 
       containers:

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -136,6 +136,10 @@ web:
 
 
 cassandra:
+  image:
+    repo: cassandra
+    tag: 3.11.3
+    pullPolicy: IfNotPresent
   enabled: true
   seeds: cassandra
   consistency: One


### PR DESCRIPTION
otherwise, we pull two cassandra images, which takes a lot of time, and can cause version mismatch issues.