### PR TITLE
Quote additional environment variable values

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.4.15
+appVersion: 0.4.16
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 version: 0.3.11

--- a/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             value: {{ .Values.debug | quote }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
-            value: {{ $value }}
+            value: {{ $value | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
Quick fix to `vault-secrets-webhook` chart to quote values of additional environment variables.