### PR TITLE
Add configmap hash annotation to pipeline deployments

### DIFF
--- a/pipeline/Chart.yaml
+++ b/pipeline/Chart.yaml
@@ -1,6 +1,6 @@
 name: pipeline
 home: https://banzaicloud.com
-version: 0.3.4
+version: 0.3.5
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline

--- a/pipeline/templates/deployment-worker.yaml
+++ b/pipeline/templates/deployment-worker.yaml
@@ -28,6 +28,8 @@ spec:
       labels:
         app: {{ include "pipeline.name" . }}-worker
         release: "{{ .Release.Name }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 
     spec:
       containers:

--- a/pipeline/templates/deployment.yaml
+++ b/pipeline/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         app: {{ include "pipeline.name" . }}
         release: "{{ .Release.Name }}"
     annotations:
+      checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     {{- if .Values.metrics.enabled  }}
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"


### PR DESCRIPTION
This is to make sure we won't have to manually restart Pipeline and Worker pods.