### PR TITLE
cicd: support unverified ssl webhooks

### DIFF
--- a/cicd/Chart.yaml
+++ b/cicd/Chart.yaml
@@ -1,6 +1,6 @@
 name: cicd
 home: https://banzaicloud.com/
-version: 2.0.1
+version: 2.0.2
 description: Pipeline CICD is a Continuous Integration platform built on Kubernetes.
 
 keywords:
@@ -11,7 +11,7 @@ keywords:
   - kubernetes
   - banzaicloud
 
-appVersion: 0.8.7
+appVersion: 0.8.8
 
 maintainers:
   - name: Banzai Cloud

--- a/cicd/templates/deployment.yaml
+++ b/cicd/templates/deployment.yaml
@@ -100,6 +100,8 @@ spec:
         {{- if hasKey .Values.ingress "hosts" }}
           - name: CICD_EXTERNAL_URL
             value: https://{{ index .Values.ingress.hosts 0 }}
+          - name: CICD_EXTERNAL_URL_INSECURE
+            value: {{ .Values.externalURLInsecure }}
         {{- end }}
 
           - name: CICD_BUILD_URL

--- a/cicd/values.yaml
+++ b/cicd/values.yaml
@@ -179,7 +179,5 @@ agent:
   #    memory: 2Gi
   #    cpu: 1
 
-## Uncomment this if you want to set a specific shared secret between
-## the agents and servers, otherwise this will be auto-generated.
-##
-sharedSecret: "ss"
+# Specifies if the external URL where CICD is called by webhooks is using a custom certificate
+externalURLInsecure: false


### PR DESCRIPTION
In case of custom signed CP certificates we have to skip verification in the webhooks.