### PR TITLE
pipeline: fix worker SHA annotation

### DIFF
--- a/pipeline/Chart.yaml
+++ b/pipeline/Chart.yaml
@@ -1,6 +1,6 @@
 name: pipeline
 home: https://banzaicloud.com
-version: 0.3.7
+version: 0.3.8
 description: A Helm chart for Banzai Cloud Pipeline, a solution-oriented application platform which allows enterprises to develop, deploy and securely scale container-based applications in multi- and hybrid-cloud environments.
 keywords:
   - pipeline
@@ -8,7 +8,7 @@ keywords:
   - banzaicloud
   - cloud
 
-appVersion: 0.21.0
+appVersion: 0.21.1
 
 maintainers:
 - name: Banzai Cloud

--- a/pipeline/templates/deployment-worker.yaml
+++ b/pipeline/templates/deployment-worker.yaml
@@ -29,7 +29,7 @@ spec:
         app: {{ include "pipeline.name" . }}-worker
         release: "{{ .Release.Name }}"
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
 
     spec:
       containers:

--- a/pipeline/values.yaml
+++ b/pipeline/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 strategy: {}
 image:
   repository: banzaicloud/pipeline
-  tag: 0.21.0
+  tag: 0.21.1
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
numbers can cause issues in the `map[string]string` type annotations during parsing