### PR TITLE
[vault-secrets-webhook] Mutate configMaps

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.17-rc.2"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.14
+version: 0.3.15
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -83,11 +83,11 @@ items:
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
-  - name: configmaps.{{ template "vault-configmaps-webhook.name" . }}.admission.banzaicloud.com
+  - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
     clientConfig:
       service:
         namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-configmaps-webhook.fullname" . }}
+        name: {{ template "vault-secrets-webhook.fullname" . }}
         path: /configmaps
       caBundle: {{ b64enc $ca.Cert }}
     rules:

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -83,3 +83,34 @@ items:
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
+  - name: configmaps.{{ template "vault-configmaps-webhook.name" . }}.admission.banzaicloud.com
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ template "vault-configmaps-webhook.fullname" . }}
+        path: /configmaps
+      caBundle: {{ b64enc $ca.Cert }}
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - "*"
+        apiVersions:
+          - "*"
+        resources:
+          - configmaps
+    failurePolicy: Fail
+    namespaceSelector:
+    {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+    {{- end }}
+      matchExpressions:
+    {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 6 }}
+    {{- end }}
+      - key: name
+        operator: NotIn
+        values:
+        - {{ .Release.Namespace }}


### PR DESCRIPTION
Added option to mutate kubernetes configMaps.

This would be useful to use with other charts not supporting things like consulTemplate.
Works in pair with https://github.com/banzaicloud/bank-vaults/pull/512