### PR TITLE
Added ability to provide imagePullSecrets in vault-secrets-webhook

### DIFF
--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -46,6 +46,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 |image.pullPolicy                     |image pull policy                                  |IfNotPresent                              |
 |image.repository                     |image repo that contains the admission server      |banzaicloud/vault-secrets-webhook         |
 |image.tag                            |image tag                                          |latest                                    |
+|image.imagePullSecrets               |image pull secrets for private repositories        |[]                                        |
 |namespaceSelector                    |namespace selector to use, will limit webhook scope|{}                                        |
 |nodeSelector                         |node selector to use                               |{}                                        |
 |replicaCount                         |number of replicas                                 |1                                         |

--- a/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -28,6 +28,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ template "vault-secrets-webhook.fullname" . }}
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -10,6 +10,7 @@ image:
   repository: banzaicloud/vault-secrets-webhook
   tag: 0.4.17-rc.2
   pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
 service:
   name: vault-secrets-webhook


### PR DESCRIPTION
Add ability to provide value `image.imagePullSecrets`.

```yaml
image:
  repository: banzaicloud/vault-secrets-webhook
  tag: 0.4.17-rc.2
  pullPolicy: IfNotPresent
  imagePullSecrets:
    - name: supersecret
```