### PR TITLE
Vault fix statefulset spec

### DIFF
--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.7
+version: 0.6.8
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/vault/templates/statefulset.yaml
+++ b/vault/templates/statefulset.yaml
@@ -9,8 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  strategy:
+  updateStrategy:
     type: {{ .Values.strategy.type }}
+  serviceName: {{ template "vault.name" . }}
   selector:
     matchLabels:
       app: {{ template "vault.name" . }}
@@ -255,7 +256,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        {{- end }}        
+        {{- end }}
         {{- range .Values.vault.customSecrets }}
         - name: {{ .secretName }}
           secret:


### PR DESCRIPTION
In the new versions of kubernetes you must provide serviceName in StatefulSet spec.
Also chart had wrong update strategy spec 