### PR TITLE
Rewrite cadence chart

### DIFF
--- a/cadence/.gitignore
+++ b/cadence/.gitignore
@@ -1,0 +1,1 @@
+values.local.yaml

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
 version: 0.3.0
-appVersion: 0.5.9
+appVersion: 0.7.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.2.0
-appVersion: 0.5.8
+version: 0.3.0
+appVersion: 0.5.9
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.5.9+
+- Cadence 0.6.0+
 
 
 ## Installing the Chart

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -2,6 +2,7 @@
 
 [Cadence](https://cadenceworkflow.io/)  is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 
+
 ## TL;DR;
 
 ```bash
@@ -9,13 +10,17 @@ $ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
 $ helm repo update
 ```
 
+
 ## Introduction
 
 This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadence-UI](https://github.com/uber/cadence-web) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
+
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
+- Cadence 0.5.9+
+
 
 ## Installing the Chart
 
@@ -26,6 +31,7 @@ $ helm install --name my-release --namespace cadence banzaicloud-stable/cadence
 ```
 
 > **Tip**: List all releases using `helm list`
+
 
 ## Uninstalling the Chart
 
@@ -38,84 +44,176 @@ $ helm delete my-release
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 
+## Install the Chart with Cassandra
+
+The chart comes with a single node Cassandra by default (from [incubator/cassandra](https://github.com/helm/charts/tree/master/incubator/cassandra)).
+
+```bash
+$ helm install .
+```
+
+You can increase the number of Cassandra nodes if you want:
+
+```bash
+$ helm install --set cassandra.config.cluster_size=3 .
+```
+
+> **Note:** It takes a few minutes to start Cassandra. You can speed it up by using configuration from `values.dev.yaml`.
+
+
+## Configure the Chart to use existing Cassandra cluster
+
+You can configure the chart to use an existing Cassandra cluster instead of installing one.
+
+**Prerequisites:**
+
+- Running Cassandra cluster
+- Existing keyspaces for *default* and *visibility* stores
+- Existing user(s) with access to those keyspaces (if authentication is required)
+
+You can easily start your own Cassandra cluster using the same [incubator/cassandra](https://github.com/helm/charts/tree/master/incubator/cassandra) chart:
+
+```bash
+$ helm install -f values/cassandra.yaml --name cassandra incubator/cassandra
+```
+
+Wait for Cassandra to become ready:
+
+```bash
+$ kubectl wait --for=condition=Ready pod/cassandra-0 --timeout=90s
+```
+
+Create two Cassandra keyspaces:
+
+```bash
+$ kubectl exec -it cassandra-0 -- cqlsh -e "CREATE KEYSPACE cadence WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
+$ kubectl exec -it cassandra-0 -- cqlsh -e "CREATE KEYSPACE cadence_visibility WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
+```
+
+```bash
+$ helm install -f values/values.cassandra.yaml .
+```
+
+
+## Install the Chart with MySQL
+
+> **Note:** MySQL support is currently *beta* in Cadence.
+
+The chart can be installed with a single node MySQL (from [stable/mysql](https://github.com/helm/charts/tree/master/stable/mysql)).
+
+```bash
+$ helm install --set cassandra.enabled=false --set mysql.enabled=true .
+```
+
+
+## Configure the Chart to use existing MySQL instance
+
+You can configure the chart to use an existing MySQL instance instead of installing one.
+
+**Prerequisites:**
+
+- Running MySQL instance
+- Existing databases for *default* and *visibility* stores
+- Existing user(s) with access to those databases
+
+You can easily start your own MySQL instance using the same [stable/mysql](https://github.com/helm/charts/tree/master/stable/mysql) chart:
+
+```bash
+$ helm install -f values/mysql.yaml --name mysql stable/mysql
+```
+
+Wait for Cassandra to become ready:
+
+```bash
+$ kubectl wait --for=condition=Ready pod/$(kubectl get pods -l 'app=mysql' -o jsonpath='{..metadata.name}') --timeout=90s
+```
+
+```bash
+$ helm install -f values/values.mysql.yaml .
+```
+
+
+## Prometheus monitoring
+
+As of 0.5.8 Cadence exports Prometheus metrics. The chart supports annotating Cadence components with Prometheus annotations,
+so that Prometheus can scrape them:
+
+```bash
+$ helm install -f values/values.prom.yaml .
+```
+
+Note that you can annotate each service separately if you want. See the configuration reference bellow.
+
+
+## Scaling Cadence
+
+Cadence server components (frontend, history, matching, worker) are executed in separate Deployments, so scaling them separately is possible.
+However you can decide to apply the same replica count to each service (just like in case of resource limits and taint/affinity settings).
+
+See the configuration reference bellow for details.
+
+
 ## Configuration
 
-The following table lists the configurable parameters of the Kubeless chart and their default values.
+The following table lists the configurable parameters of the chart and their default values.
+Global options overridable per service are marked with an asterisk.
 
-| Parameter                              | Description                                | Default              |
-| -------------------------------------- | ------------------------------------------ | -------------------- |
-| `server.image.pullPolicy`              | Server Container pull policy               | `IfNotPresent`       |
-| `server.image.repository`              | Image repository for cadence Server        | `ubercadence/server` |
-| `server.image.tag`                     | Image Tag for cadence Server               | `0.5.2`              |
-| `server.logLevel`                      | Server Log level                           | `debug,info`         |
-| `server.nameOverride`                  | Override name of app                       | ``                   |
-| `server.fullnameOverride`              | Override full name of app                  | ``                   |
-| `server.bindOnLocalHost`               | Server bind on local host                  | `false`              |
-| `server.cassandraVisibilityKeyspace`   | Cassandra Visibility Keyspace              | `cadence`            |
-| `server.replicaCount`                  | Number of Server Replicas                  | `1`                  |
-| `server.frontend.enabled`              | Enable server frontend service             | `true`               |
-| `server.frontend.bindOnIP`             | Server frontend bind IP                    | `0.0.0.0`            |
-| `server.frontend.service.type`         | Server frontend service type               | `ClusterIP`          |
-| `server.frontend.service.port`         | Server frontend service port               | `7933`               |
-| `server.frontend.prometheus.timerType` | Prometheus frontend timer type             | `histogram`          |
-| `server.frontend.prometheus.port`      | Prometheus frontend scrape port            | `8000`               |
-| `server.matching.enabled`              | Enable server matching service             | `true`               |
-| `server.matching.bindOnIP`             | Server matching bind IP                    | `0.0.0.0`            |
-| `server.matching.service.type`         | Server matching service type               | `ClusterIP`          |
-| `server.matching.service.port`         | Server matching service port               | `7935`               |
-| `server.matching.prometheus.timerType` | Prometheus matching timer type             | `histogram`          |
-| `server.matching.prometheus.port`      | Prometheus matching scrape port            | `8000`               |
-| `server.history.enabled`               | Enable server history service              | `true`               |
-| `server.history.bindOnIP`              | Server history bind IP                     | `0.0.0.0`            |
-| `server.history.numHistoryShards`      | Server history shards number               | `4`                  |
-| `server.history.service.type`          | Server history service type                | `ClusterIP`          |
-| `server.history.service.port`          | Server history service port                | `7934`               |
-| `server.history.prometheus.timerType`  | Prometheus history timer type              | `histogram`          |
-| `server.history.prometheus.port`       | Prometheus history scrape port             | `8000`               |
-| `server.worker.enabled`                | Enable server worker service               | `true`               |
-| `server.worker.bindOnIP`               | Server worker bind IP                      | `0.0.0.0`            |
-| `server.worker.service.type`           | Server worker service type                 | `ClusterIP`          |
-| `server.worker.service.port`           | Server worker service port                 | `7939`               |
-| `server.worker.prometheus.timerType`   | Prometheus worker timer type               | `histogram`          |
-| `server.worker.prometheus.port`        | Prometheus worker scrape port              | `8000`               |
-| `server.resources`                     | Server CPU/Memory resource requests/limits | `{}`                 |
-| `server.nodeSelector`                  | Node labels for pod assignment             | `{}`                 |
-| `server.tolerations`                   | Toleration labels for pod assignment       | `[]`                 |
-| `server.affinity`                      | Affinity settings for pod assignment       | `{}`                 |
-| `web.enabled`                          | Enable WebUI service                       | `true`               |
-| `web.replicaCount`                     | Number of WebUI service Replicas           | `1`                  |
-| `web.image.pullPolicy`                 | WebUI service Container pull policy        | `IfNotPresent`       |
-| `web.image.repository`                 | Image repository for cadence WebUI         | `ubercadence/web`    |
-| `web.image.tag`                        | Image Tag for cadence WebUI                | `3.1.2`              |
-| `web.cadenceTchannelPeers`             | Cadence TChannel Peers                     | `cadence:7933`       |
-| `web.nameOverride`                     | Override name of app                       | ``                   |
-| `web.fullnameOverride`                 | Override full name of app                  | ``                   |
-| `web.service.type`                     | WebUI service type                         | `ClusterIP`          |
-| `web.service.port`                     | WebUI service port                         | `80`                 |
-| `web.ingress.enabled`                  | Enables WebUI Ingress                      | `false`              |
-| `web.ingress.annotations`              | WebUI Ingress annotations                  | `{}`                 |
-| `web.ingress.hosts`                    | WebUI Ingress hosts                        | `/`                  |
-| `web.ingress.tls`                      | WebUI Ingress tls config                   | `[]`                 |
-| `web.resources`                        | WebUI CPU/Memory resource requests/limits  | `{}`                 |
-| `web.nodeSelector`                     | Node labels for pod assignment             | `{}`                 |
-| `web.tolerations`                      | Toleration labels for pod assignment       | `[]`                 |
-| `web.affinity`                         | Affinity settings for pod assignment       | `{}`                 |
-| `cassandra.enabled`                    | Enable Cassandra cluster install           | `true`               |
-| `cassandra.config.cluster_size`        | Cassandra cluster node number              | `1`                  |
-| `cassandra.seeds`                      | Cassandra Seeds                            | `cassandra`          |
-| `cassandra.consistency`                | Cassandra Consistency                      | `One`                |
-| `cassandra.keyspace`                   | Cassandra keyspace name                    | `cadence`            |
+| Parameter                                     | Description                                      | Default                      |
+|-----------------------------------------------|--------------------------------------------------|------------------------------|
+| `nameOverride`                                | Override name of the application                 | ``                           |
+| `fullnameOverride`                            | Override full name of the application            | ``                           |
+| `server.image.repository`                     | Server image repository                          | `banzaicloud/cadence-server` |
+| `server.image.tag`                            | Server image tag                                 | `0.5.9`                      |
+| `server.image.pullPolicy`                     | Server image pull policy                         | `IfNotPresent`               |
+| `server.replicaCount`*                        | Server replica count                             | `1`                          |
+| `server.metrics.prometheus.timerType`*        | Prometheus timer type                            | `histogram`                  |
+| `server.podAnnotations`*                      | Server pod annotations                           | `{}`                         |
+| `server.resources`*                           | Server CPU/Memory resource requests/limits       | `{}`                         |
+| `server.nodeSelector`*                        | Node labels for pod assignment                   | `{}`                         |
+| `server.tolerations`*                         | Toleration labels for pod assignment             | `[]`                         |
+| `server.affinity`*                            | Affinity settings for pod assignment             | `{}`                         |
+| `server.config.logLevel`                      | Server log level                                 | `debug,info`                 |
+| `server.config.numHistoryShards`              | Number of history shards                         | `4`                          |
+| `server.config.persistence.[store].driver`    | Connection driver                                | `cassandra`                  |
+| `server.config.persistence.[store].cassandra` | Cassandra connection details (see `values.yaml`) | `{}`                         |
+| `server.config.persistence.[store].sql`       | SQL connection details (see `values.yaml`)       | `{}`                         |
+| `server.[service].service.type`               | `[service]` service type                         | `ClusterIP`                  |
+| `server.[service].service.port`               | `[service]` service port                         | `7933/7934/7935/7939`        |
+| `server.[service].prometheus.timerType`       | `[service]` Prometheus timer type                | ``                           |
+| `server.[service].podAnnotations`             | `[service]` pod annotations                      | `{}`                         |
+| `server.[service].resources`                  | `[service]` CPU/Memory resource requests/limits  | `{}`                         |
+| `server.[service].nodeSelector`               | `[service]` Node labels for pod assignment       | `{}`                         |
+| `server.[service].tolerations`                | `[service]` Toleration labels for pod assignment | `[]`                         |
+| `server.[service].affinity`                   | `[service]` Affinity settings for pod assignment | `{}`                         |
+| `web.enabled`                                 | Enable WebUI service                             | `true`                       |
+| `web.replicaCount`                            | Number of WebUI service Replicas                 | `1`                          |
+| `web.image.repository`                        | WebUI image repository                           | `ubercadence/web`            |
+| `web.image.tag`                               | WebUI image tag                                  | `3.3.1`                      |
+| `web.image.pullPolicy`                        | WebUI image pull policy                          | `IfNotPresent`               |
+| `web.service.type`                            | WebUI service type                               | `ClusterIP`                  |
+| `web.service.port`                            | WebUI service port                               | `80`                         |
+| `web.ingress.enabled`                         | Enable WebUI Ingress                             | `false`                      |
+| `web.ingress.annotations`                     | WebUI Ingress annotations                        | `{}`                         |
+| `web.ingress.hosts`                           | WebUI Ingress hosts                              | `/`                          |
+| `web.ingress.tls`                             | WebUI Ingress tls config                         | `[]`                         |
+| `web.resources`                               | WebUI CPU/Memory resource requests/limits        | `{}`                         |
+| `web.nodeSelector`                            | Node labels for pod assignment                   | `{}`                         |
+| `web.tolerations`                             | Toleration labels for pod assignment             | `[]`                         |
+| `web.affinity`                                | Affinity settings for pod assignment             | `{}`                         |
+| `cassandra.enabled`                           | Install Cassandra cluster                        | `true`                       |
+| `cassandra.config.cluster_size`               | Cassandra cluster node number                    | `1`                          |
+| `mysql.enabled`                               | Install MySQL                                    | `false`                      |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
-```console
+```bash
 $ helm install --name my-release --set server.image.tag=0.5.2 banzaicloud-stable/cadence
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
-```console
+```bash
 $ helm install --name my-release --values values.yaml banzaicloud-stable/cadence
 ```

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -153,6 +153,11 @@ However you can decide to apply the same replica count to each service (just lik
 See the configuration reference bellow for details.
 
 
+## Recommended setup
+
+
+
+
 ## Configuration
 
 The following table lists the configurable parameters of the chart and their default values.
@@ -162,8 +167,8 @@ Global options overridable per service are marked with an asterisk.
 |-----------------------------------------------|--------------------------------------------------|------------------------------|
 | `nameOverride`                                | Override name of the application                 | ``                           |
 | `fullnameOverride`                            | Override full name of the application            | ``                           |
-| `server.image.repository`                     | Server image repository                          | `banzaicloud/cadence-server` |
-| `server.image.tag`                            | Server image tag                                 | `0.5.9`                      |
+| `server.image.repository`                     | Server image repository                          | `ubercadence/server`         |
+| `server.image.tag`                            | Server image tag                                 | `0.6.0`                      |
 | `server.image.pullPolicy`                     | Server image pull policy                         | `IfNotPresent`               |
 | `server.replicaCount`*                        | Server replica count                             | `1`                          |
 | `server.metrics.prometheus.timerType`*        | Prometheus timer type                            | `histogram`                  |
@@ -200,6 +205,8 @@ Global options overridable per service are marked with an asterisk.
 | `web.nodeSelector`                            | Node labels for pod assignment                   | `{}`                         |
 | `web.tolerations`                             | Toleration labels for pod assignment             | `[]`                         |
 | `web.affinity`                                | Affinity settings for pod assignment             | `{}`                         |
+| `schema.setup`                                | Create database or keyspace                      | `true`                       |
+| `schema.update`                               | Update schema                                    | `true`                       |
 | `cassandra.enabled`                           | Install Cassandra cluster                        | `true`                       |
 | `cassandra.config.cluster_size`               | Cassandra cluster node number                    | `1`                          |
 | `mysql.enabled`                               | Install MySQL                                    | `false`                      |

--- a/cadence/migrations.md
+++ b/cadence/migrations.md
@@ -1,0 +1,92 @@
+# Running migrations for Cadence
+
+As of version 0.7.1 the production Cadence image does not automatically run migrations.
+While the helm chart provides a way to automatically run them,
+it's recommended to run them manually before installing/upgrading Cadence.
+
+This guide contains commands to run migrations on Cassandra or MySQL.
+
+The first step is to start a new shell in a Cadence container:
+
+```bash
+export CADENCE_VERSION=0.7.1
+docker run --rm -it ubercadence/server:${CADENCE_VERSION} bash
+```
+
+
+## Cassandra
+
+Set up environment variables:
+
+```bash
+export CASSANDRA_HOST=docker.for.mac.host.internal
+export CASSANDRA_PORT=9042
+# Optionally:
+# export CASSANDRA_USER=
+# export CASSANDRA_PASSWORD=
+export CADENCE_KEYSPACE=cadence
+export VISIBILITY_KEYSPACE=cadence_visibility
+```
+
+
+### Create keyspaces
+
+```bash
+cadence-cassandra-tool create -k ${CADENCE_KEYSPACE}
+cadence-cassandra-tool create -k ${VISIBILITY_KEYSPACE}
+```
+
+### Set up schema for the first time
+
+```bash
+CASSANDRA_KEYSPACE=${CADENCE_KEYSPACE} cadence-cassandra-tool setup-schema -v 0.0
+CASSANDRA_KEYSPACE=${VISIBILITY_KEYSPACE} cadence-cassandra-tool setup-schema -v 0.0
+```
+
+
+### Update schema
+
+```bash
+CASSANDRA_KEYSPACE=${CADENCE_KEYSPACE} cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/cadence/versioned
+CASSANDRA_KEYSPACE=${VISIBILITY_KEYSPACE} cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/visibility/versioned
+```
+
+
+## MySQL
+
+Set up environment variables:
+
+```bash
+export SQL_DRIVER=mysql
+export SQL_HOST=docker.for.mac.host.internal
+export SQL_PORT=3306
+# Optionally:
+# export SQL_USER=
+# export SQL_PASSWORD=
+export CADENCE_DATABASE=cadence
+export VISIBILITY_DATABASE=cadence_visibility
+```
+
+
+### Create databases
+
+```bash
+cadence-sql-tool create --db ${CADENCE_DATABASE}
+cadence-sql-tool create --db ${VISIBILITY_DATABASE}
+```
+
+
+### Set up schema for the first time
+
+```bash
+SQL_DATABASE=${CADENCE_DATABASE} cadence-sql-tool setup-schema -v 0.0
+SQL_DATABASE=${VISIBILITY_DATABASE} cadence-sql-tool setup-schema -v 0.0
+```
+
+
+### Update schema
+
+```bash
+SQL_DATABASE=${CADENCE_DATABASE} cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/cadence/versioned
+SQL_DATABASE=${VISIBILITY_DATABASE} cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/visibility/versioned
+```

--- a/cadence/requirements.yaml
+++ b/cadence/requirements.yaml
@@ -1,5 +1,9 @@
 dependencies:
   - name: cassandra
-    version: ^0.10.4
+    version: ^0.13.1
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: cassandra.enabled
+  - name: mysql
+    version: ^1.2.0
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mysql.enabled

--- a/cadence/templates/NOTES.txt
+++ b/cadence/templates/NOTES.txt
@@ -1,3 +1,3 @@
-To verify that cadence has started, run:
+To verify that Cadence has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/cadence/templates/_helpers.tpl
+++ b/cadence/templates/_helpers.tpl
@@ -31,8 +31,168 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Call nested templates.
+Source: https://stackoverflow.com/a/52024583/3027614
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 }}
+{{- $template := index . 2 }}
+{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}
 
-{{- define "cassandra.fullname" -}}
-{{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- define "cadence.frontend.internalPort" -}}
+7933
 {{- end -}}
 
+{{- define "cadence.history.internalPort" -}}
+7934
+{{- end -}}
+
+{{- define "cadence.matching.internalPort" -}}
+7935
+{{- end -}}
+
+{{- define "cadence.worker.internalPort" -}}
+7939
+{{- end -}}
+
+{{- define "cadence.persistence.schema" -}}
+{{- if eq . "default" -}}
+{{- print "cadence" -}}
+{{- else -}}
+{{- print . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.driver" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.driver -}}
+{{- $storeConfig.driver -}}
+{{- else if $global.Values.cassandra.enabled -}}
+{{- print "cassandra" -}}
+{{- else if $global.Values.mysql.enabled -}}
+{{- print "sql" -}}
+{{- else -}}
+{{- required (printf "Please specify persistence driver for %s store" $store) $storeConfig.driver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.hosts" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.cassandra.hosts -}}
+{{- $storeConfig.cassandra.hosts | join "," -}}
+{{- else if and $global.Values.cassandra.enabled (eq (include "cadence.persistence.driver" (list $global $store)) "cassandra") -}}
+{{- include "cassandra.hosts" $global -}}
+{{- else -}}
+{{- required (printf "Please specify cassandra hosts for %s store" $store) $storeConfig.cassandra.hosts -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.port" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.cassandra.port -}}
+{{- $storeConfig.cassandra.port -}}
+{{- else if and $global.Values.cassandra.enabled (eq (include "cadence.persistence.driver" (list $global $store)) "cassandra") -}}
+{{- $global.Values.cassandra.config.ports.cql -}}
+{{- else -}}
+{{- required (printf "Please specify cassandra port for %s store" $store) $storeConfig.cassandra.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.driver" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.driver -}}
+{{- $storeConfig.sql.driver -}}
+{{- else if $global.Values.mysql.enabled -}}
+{{- print "mysql" -}}
+{{- else -}}
+{{- required (printf "Please specify sql driver for %s store" $store) $storeConfig.sql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.host" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.host -}}
+{{- $storeConfig.sql.host -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.driver" (list $global $store)) "mysql")) -}}
+{{- include "mysql.host" $global -}}
+{{- else -}}
+{{- required (printf "Please specify sql host for %s store" $store) $storeConfig.sql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.port" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.port -}}
+{{- $storeConfig.sql.port -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.driver" (list $global $store)) "mysql")) -}}
+{{- $global.Values.mysql.service.port -}}
+{{- else -}}
+{{- required (printf "Please specify sql port for %s store" $store) $storeConfig.sql.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.user" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.user -}}
+{{- $storeConfig.sql.user -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.driver" (list $global $store)) "mysql")) -}}
+{{- $global.Values.mysql.mysqlUser -}}
+{{- else -}}
+{{- required (printf "Please specify sql user for %s store" $store) $storeConfig.sql.user -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.password" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.password -}}
+{{- $storeConfig.sql.password -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.driver" (list $global $store)) "mysql")) -}}
+{{- $global.Values.mysql.mysqlPassword -}}
+{{- else -}}
+{{- required (printf "Please specify sql password for %s store" $store) $storeConfig.sql.password -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+All Cassandra hosts.
+*/}}
+{{- define "cassandra.hosts" -}}
+{{- range $i := (until (int .Values.cassandra.config.cluster_size)) }}
+{{- $cassandraName := include "call-nested" (list $ "cassandra" "cassandra.fullname") -}}
+{{- printf "%s-%d.%s.%s.svc.cluster.local," $cassandraName $i $cassandraName $.Release.Namespace -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+The first Cassandra host in the stateful set.
+*/}}
+{{- define "cassandra.host" -}}
+{{- $cassandraName := include "call-nested" (list . "cassandra" "cassandra.fullname") -}}
+{{- printf "%s-0.%s.%s.svc.cluster.local" $cassandraName $cassandraName .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+MySQL host.
+*/}}
+{{- define "mysql.host" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "call-nested" (list . "mysql" "mysql.fullname")) .Release.Namespace -}}
+{{- end -}}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -135,3 +135,4 @@ data:
 
     publicClient:
       hostPort: "127.0.0.1:7933"
+      DNSPort: "{{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -63,10 +63,10 @@ data:
       name: cadence
       bootstrapMode: dns
       bootstrapHosts:
-        - {{ include "cadence.fullname" . }}-frontend-headless:{{ .Values.server.frontend.service.port }}
-        - {{ include "cadence.fullname" . }}-history-headless:{{ .Values.server.history.service.port }}
-        - {{ include "cadence.fullname" . }}-matching-headless:{{ .Values.server.matching.service.port }}
-        - {{ include "cadence.fullname" . }}-worker-headless:{{ .Values.server.worker.service.port }}
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port }}
       maxJoinDuration: 30s
 
     services:
@@ -134,4 +134,4 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "{{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}"
+      hostPort: "{{ include "cadence.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/part-of: {{ .Chart.Name }}
 data:
-  production.yaml: |-
+  config_template.yaml: |-
     log:
       stdout: true
       level: {{ .Values.server.config.logLevel | quote }}
@@ -28,7 +28,7 @@ data:
             keyspace: {{ .Values.server.config.persistence.default.cassandra.keyspace }}
             consistency: {{ .Values.server.config.persistence.default.cassandra.consistency }}
             user: {{ .Values.server.config.persistence.default.cassandra.user }}
-            password: {{ .Values.server.config.persistence.default.cassandra.password }}
+            password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list . "default")) "sql" }}
           sql:
@@ -37,7 +37,7 @@ data:
             connectAddr: "{{ include "cadence.persistence.sql.host" (list . "default") }}:{{ include "cadence.persistence.sql.port" (list . "default") }}"
             connectProtocol: "tcp"
             user: {{ include "cadence.persistence.sql.user" (list . "default") }}
-            password: {{ include "cadence.persistence.sql.password" (list . "default") }}
+            password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
           {{- end }}
         visibility:
           {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "cassandra" }}
@@ -47,7 +47,7 @@ data:
             keyspace: {{ .Values.server.config.persistence.visibility.cassandra.keyspace }}
             consistency: {{ .Values.server.config.persistence.visibility.cassandra.consistency }}
             user: {{ .Values.server.config.persistence.visibility.cassandra.user }}
-            password: {{ .Values.server.config.persistence.visibility.cassandra.password }}
+            password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "sql" }}
           sql:
@@ -56,7 +56,7 @@ data:
             connectAddr: "{{ include "cadence.persistence.sql.host" (list . "visibility") }}:{{ include "cadence.persistence.sql.port" (list . "visibility") }}"
             connectProtocol: "tcp"
             user: {{ include "cadence.persistence.sql.user" (list . "visibility") }}
-            password: {{ include "cadence.persistence.sql.password" (list . "visibility") }}
+            password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
           {{- end }}
 
     ringpop:
@@ -134,5 +134,4 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "127.0.0.1:7933"
-      DNSPort: "{{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}"
+      hostPort: "{{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -5,94 +5,124 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
 data:
-{{- if semverCompare "<= 0.5.5" .Values.server.image.tag }}
-  docker_template.yaml: |-
-{{- else }}
-  docker_template_cassandra.yaml: |-
-{{- end }}
+  production.yaml: |-
     log:
       stdout: true
-      level: "${LOG_LEVEL}"
+      level: {{ .Values.server.config.logLevel | quote }}
 
     persistence:
-      defaultStore: cass-default
-      visibilityStore: cass-visibility
-      numHistoryShards: ${NUM_HISTORY_SHARDS}
+      defaultStore: default
+      visibilityStore: visibility
+      numHistoryShards: {{ .Values.server.config.numHistoryShards }}
       datastores:
-        cass-default:
+        default:
+          {{- if eq (include "cadence.persistence.driver" (list . "default")) "cassandra" }}
           cassandra:
-            hosts: "${CASSANDRA_SEEDS}"
-            keyspace: "${KEYSPACE}"
-            consistency: "${CASSANDRA_CONSISTENCY}"
-        cass-visibility:
+            hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "default") }}
+            port: {{ include "cadence.persistence.cassandra.port" (list . "default") }}
+            keyspace: {{ .Values.server.config.persistence.default.cassandra.keyspace }}
+            consistency: {{ .Values.server.config.persistence.default.cassandra.consistency }}
+            user: {{ .Values.server.config.persistence.default.cassandra.user }}
+            password: {{ .Values.server.config.persistence.default.cassandra.password }}
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list . "default")) "sql" }}
+          sql:
+            driverName: {{ include "cadence.persistence.sql.driver" (list . "default") }}
+            databaseName: {{ .Values.server.config.persistence.default.sql.database }}
+            connectAddr: "{{ include "cadence.persistence.sql.host" (list . "default") }}:{{ include "cadence.persistence.sql.port" (list . "default") }}"
+            connectProtocol: "tcp"
+            user: {{ include "cadence.persistence.sql.user" (list . "default") }}
+            password: {{ include "cadence.persistence.sql.password" (list . "default") }}
+          {{- end }}
+        visibility:
+          {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "cassandra" }}
           cassandra:
-            hosts: "${CASSANDRA_SEEDS}"
-            keyspace: "${VISIBILITY_KEYSPACE}"
-            consistency: "${CASSANDRA_CONSISTENCY}"
+            hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "visibility") }}
+            port: {{ include "cadence.persistence.cassandra.port" (list . "visibility") }}
+            keyspace: {{ .Values.server.config.persistence.visibility.cassandra.keyspace }}
+            consistency: {{ .Values.server.config.persistence.visibility.cassandra.consistency }}
+            user: {{ .Values.server.config.persistence.visibility.cassandra.user }}
+            password: {{ .Values.server.config.persistence.visibility.cassandra.password }}
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "sql" }}
+          sql:
+            driverName: {{ include "cadence.persistence.sql.driver" (list . "visibility") }}
+            databaseName: {{ .Values.server.config.persistence.visibility.sql.database }}
+            connectAddr: "{{ include "cadence.persistence.sql.host" (list . "visibility") }}:{{ include "cadence.persistence.sql.port" (list . "visibility") }}"
+            connectProtocol: "tcp"
+            user: {{ include "cadence.persistence.sql.user" (list . "visibility") }}
+            password: {{ include "cadence.persistence.sql.password" (list . "visibility") }}
+          {{- end }}
 
     ringpop:
       name: cadence
-      bootstrapMode: hosts
-      bootstrapHosts: ${RINGPOP_SEEDS_JSON_ARRAY}
+      bootstrapMode: dns
+      bootstrapHosts:
+        - {{ include "cadence.fullname" . }}-frontend-headless:{{ .Values.server.frontend.service.port }}
+        - {{ include "cadence.fullname" . }}-history-headless:{{ .Values.server.history.service.port }}
+        - {{ include "cadence.fullname" . }}-matching-headless:{{ .Values.server.matching.service.port }}
+        - {{ include "cadence.fullname" . }}-worker-headless:{{ .Values.server.worker.service.port }}
       maxJoinDuration: 30s
 
     services:
       frontend:
         rpc:
-          port: {{ .Values.server.frontend.service.port }}
-          bindOnIP: {{ .Values.server.frontend.bindOnIP }}
+          port: {{ include "cadence.frontend.internalPort" . }}
+          bindOnIP: "0.0.0.0"
         metrics:
           tags:
             type: frontend
           prometheus:
-            timerType: {{ .Values.server.frontend.prometheus.timerType }}
-            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.frontend.prometheus.port }}
-
-      matching:
-        rpc:
-          port: {{ .Values.server.matching.service.port }}
-          bindOnIP: {{ .Values.server.matching.bindOnIP }}
-        metrics:
-          tags:
-            type: matching
-          prometheus:
-            timerType: {{ .Values.server.matching.prometheus.timerType }}
-            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.matching.prometheus.port }}
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.frontend.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
 
       history:
         rpc:
-          port: {{ .Values.server.history.service.port }}
-          bindOnIP: {{ .Values.server.history.bindOnIP }}
+          port: {{ include "cadence.history.internalPort" . }}
+          bindOnIP: "0.0.0.0"
         metrics:
           tags:
             type: history
           prometheus:
-            timerType: {{ .Values.server.history.prometheus.timerType }}
-            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.history.prometheus.port }}
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.history.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
+
+      matching:
+        rpc:
+          port: {{ include "cadence.matching.internalPort" . }}
+          bindOnIP: "0.0.0.0"
+        metrics:
+          tags:
+            type: matching
+          prometheus:
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.matching.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
 
       worker:
         rpc:
-          port: {{ .Values.server.worker.service.port }}
-          bindOnIP: {{ .Values.server.worker.bindOnIP }}
+          port: {{ include "cadence.worker.internalPort" . }}
+          bindOnIP: "0.0.0.0"
         metrics:
           tags:
             type: worker
           prometheus:
-            timerType: {{ .Values.server.worker.prometheus.timerType }}
-            listenAddress: {{ .Values.server.frontend.bindOnIP }}:{{ .Values.server.worker.prometheus.port }}
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
 
-    clustersInfo:
+    clusterMetadata:
       enableGlobalDomain: false
       failoverVersionIncrement: 10
       masterClusterName: "active"
       currentClusterName: "active"
-      clusterInitialFailoverVersion:
-        active: 0
-      clusterAddress:
+      clusterInformation:
         active:
+          enabled: true
+          initialFailoverVersion: 0
           rpcName: "cadence-frontend"
           rpcAddress: "127.0.0.1:7933"
 
@@ -101,20 +131,7 @@ data:
       toDC: ""
 
     archival:
-      enableArchival: true
-      blobstore:
-        storeDirectory: "/tmp/blobstore/"
-        defaultBucket:
-          name: "cadence-development"
-          owner: "cadence"
-          retentionDays: 10
-        customBuckets:
-          - name: "custom-bucket-1"
-            owner: "custom-owner-1"
-            retentionDays: 10
-          - name: "custom-bucket-2"
-            owner: "custom-owner-2"
-            retentionDays: 5
-    
+      status: "disabled"
+
     publicClient:
-      hostPort: "127.0.0.1:{{ .Values.server.frontend.service.port }}"
+      hostPort: "127.0.0.1:7933"

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -1,157 +1,110 @@
+{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cadence.fullname" . }}
+  name: {{ include "cadence.fullname" $ }}-{{ $service }}
   labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cadence.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "cadence.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $service }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "cadence.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.server.annotations }}
+        app.kubernetes.io/name: {{ include "cadence.name" $ }}
+        helm.sh/chart: {{ include "cadence.chart" $ }}
+        app.kubernetes.io/managed-by: {{ $.Release.Service }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: {{ $service }}
+        app.kubernetes.io/part-of: {{ $.Chart.Name }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") $ | sha256sum }}
+        {{- with (default $.Values.server.podAnnotations $serviceValues.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       initContainers:
-      - name: check-cassandra
-        image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
-        imagePullPolicy: {{ .Values.cassandra.image.pullPolicy | quote }}
-        command: ['sh', '-c', 'until cqlsh {{ template "cassandra.fullname" . }} -e "describe cluster"; do echo waiting for cassandra; sleep 2; done;']
-
+        {{- if $.Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        - name: check-cassandra-cadence-schema
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.default.cassandra.keyspace }}$; do echo waiting for default keyspace to become ready; sleep 1; done;']
+        - name: check-cassandra-visibility-schema
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.visibility.cassandra.keyspace }}$; do echo waiting for visibility keyspace to become ready; sleep 1; done;']
+        {{- else if $.Values.mysql.enabled  }}
+        - name: check-mysql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ $.Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- else }}
+          []
+        {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-        env:
-        - name: LOG_LEVEL
-          value: "{{ .Values.server.logLevel }}"
-        - name: CASSANDRA_SEEDS
-          value: {{ template "cassandra.fullname" . }}
-        - name: KEYSPACE
-          value: "{{ .Values.cassandra.keyspace }}"
-        - name: VISIBILITY_KEYSPACE
-          value: "{{ .Values.cassandraVisibilityKeyspace }}"
-        - name: CASSANDRA_CONSISTENCY
-          value: "{{ .Values.cassandra.consistency }}"
-        - name: NUM_HISTORY_SHARDS
-          value: "{{ .Values.server.history.numHistoryShards }}"
-        - name: BIND_ON_LOCALHOST
-          value: "{{ .Values.server.bindOnLocalHost }}"
-
-        ports:
-        {{- if .Values.server.frontend.enabled }}
-          - name: frontend
-            containerPort: {{ .Values.server.frontend.service.port }}
-            protocol: TCP
-          - name: metrics-front
-            containerPort: {{ .Values.server.frontend.prometheus.port }}
-            protocol: TCP
-        {{- end }}
-        {{- if .Values.server.matching.enabled }}
-          - name: matching
-            containerPort: {{ .Values.server.matching.service.port }}
-            protocol: TCP
-          - name: metrics-match
-            containerPort: {{ .Values.server.matching.prometheus.port }}
-            protocol: TCP
-        {{- end }}
-        {{- if .Values.server.history.enabled }}
-          - name: history
-            containerPort: {{ .Values.server.history.service.port }}
-            protocol: TCP
-          - name: metrics-history
-            containerPort: {{ .Values.server.history.prometheus.port }}
-            protocol: TCP
-        {{- end }}
-        {{- if .Values.server.worker.enabled }}
-          - name: worker
-            containerPort: {{ .Values.server.worker.service.port }}
-            protocol: TCP
-          - name: metrics-worker
-            containerPort: {{ .Values.server.worker.prometheus.port }}
-            protocol: TCP
-        {{- end }}
-
-        livenessProbe:
-          {{- if .Values.server.frontend.enabled }}
-          initialDelaySeconds: 150
-          tcpSocket:
-            port: {{ .Values.server.frontend.service.port }}
-          {{- end }}
-          {{- if .Values.server.matching.enabled }}
-          initialDelaySeconds: 150
-          tcpSocket:
-            port: {{ .Values.server.matching.service.port }}
-          {{- end }}
-          {{- if .Values.server.history.enabled }}
-          initialDelaySeconds: 150
-          tcpSocket:
-            port: {{ .Values.server.history.service.port }}
-          {{- end }}
-          {{- if .Values.server.worker.enabled }}
-          initialDelaySeconds: 150
-          tcpSocket:
-            port: {{ .Values.server.worker.service.port }}
-          {{- end }}
-
-        readinessProbe:
-          {{- if .Values.server.frontend.enabled }}
-          initialDelaySeconds: 50
-          tcpSocket:
-            port: {{ .Values.server.frontend.service.port }}
-          {{- end }}
-          {{- if .Values.server.matching.enabled }}
-          initialDelaySeconds: 50
-          tcpSocket:
-            port: {{ .Values.server.matching.service.port }}
-          {{- end }}
-          {{- if .Values.server.history.enabled }}
-          initialDelaySeconds: 50
-          tcpSocket:
-            port: {{ .Values.server.history.service.port }}
-          {{- end }}
-          {{- if .Values.server.worker.enabled }}
-          initialDelaySeconds: 50
-          tcpSocket:
-            port: {{ .Values.server.worker.service.port }}
-          {{- end }}
-        volumeMounts:
-{{- if semverCompare "<= 0.5.5" .Values.server.image.tag }}
-        - name: "{{ .Chart.Name }}-config"
-          mountPath: /cadence/config/docker_template.yaml
-          subPath: docker_template.yaml
-{{- else }}
-        - name: "{{ .Chart.Name }}-config"
-          mountPath: /cadence/config/docker_template_cassandra.yaml
-          subPath: docker_template_cassandra.yaml
-{{- end }}
-        resources:
-          {{- toYaml .Values.server.resources | nindent 12 }}
-
+        - name: {{ $.Chart.Name }}-{{ $service }}
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          args: ['cadence-server', '--root', '/etc/cadence', '--env', 'production', 'start', '--services', '{{ $service }}']
+          env:
+            - name: PATH
+              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ports:
+            - name: rpc
+              containerPort: {{ include (printf "cadence.%s.internalPort" $service) $ }}
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
+          readinessProbe:
+            initialDelaySeconds: 10
+            tcpSocket:
+              port: rpc
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cadence/config/
+          resources:
+            {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
       volumes:
-      - name: "{{ .Chart.Name }}-config"
-        configMap:
-          name: {{ include "cadence.fullname" . }}
-      {{- with .Values.nodeSelector }}
+        - name: config
+          configMap:
+            name: {{ include "cadence.fullname" $ }}
+      {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+    {{- with (default $.Values.server.affinity $serviceValues.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default $.Values.server.tolerations $serviceValues.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+---
+{{- end }}

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -66,10 +66,19 @@ spec:
         - name: {{ $.Chart.Name }}-{{ $service }}
           image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
-          args: ['cadence-server', '--root', '/etc/cadence', '--env', 'production', 'start', '--services', '{{ $service }}']
           env:
-            - name: PATH
-              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            - name: SERVICES
+              value: {{ $service }}
+            - name: CADENCE_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ "default") }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ "default") }}
+            - name: CADENCE_VISIBILITY_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ "visibility") }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ "visibility") }}
           ports:
             - name: rpc
               containerPort: {{ include (printf "cadence.%s.internalPort" $service) $ }}
@@ -87,7 +96,8 @@ spec:
               port: rpc
           volumeMounts:
             - name: config
-              mountPath: /etc/cadence/config/
+              mountPath: /etc/cadence/config/config_template.yaml
+              subPath: config_template.yaml
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
       volumes:

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cadence.fullname" $ }}-{{ $service }}
+  name: {{ include "cadence.componentname" (list $ $service) }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" $ }}
     helm.sh/chart: {{ include "cadence.chart" $ }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "cadence.fullname" . }}-schema-setup
+  name: {{ include "cadence.componentname" (list . "schema-setup") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
@@ -23,7 +23,7 @@ spec:
   backoffLimit: 10
   template:
     metadata:
-      name: {{ include "cadence.fullname" . | trunc 42 | trimSuffix "-" }}-schema-setup
+      name: {{ include "cadence.componentname" (list . "schema-setup") }}
       labels:
         app.kubernetes.io/name: {{ include "cadence.name" . }}
         helm.sh/chart: {{ include "cadence.chart" . }}
@@ -150,7 +150,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "cadence.fullname" . }}-schema-update
+  name: {{ include "cadence.componentname" (list . "schema-update") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
@@ -171,7 +171,7 @@ spec:
   backoffLimit: 10
   template:
     metadata:
-      name: {{ include "cadence.fullname" . | trunc 42 | trimSuffix "-" }}-schema-update
+      name: {{ include "cadence.componentname" (list . "schema-update") }}
       labels:
         app.kubernetes.io/name: {{ include "cadence.name" . }}
         helm.sh/chart: {{ include "cadence.chart" . }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -1,0 +1,252 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cadence.fullname" . }}-schema-setup
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      name: {{ include "cadence.fullname" . | trunc 42 | trimSuffix "-" }}-schema-setup
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      restartPolicy: "OnFailure"
+      initContainers:
+        {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+        {{- if .Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        {{- else if .Values.mysql.enabled }}
+        - name: check-mysql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ .Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- end }}
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: create-{{ $store }}-store
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+          # args: ["cadence-cassandra-tool", "create", "-k", "{{ $storeConfig.cassandra.keyspace }}"]
+          args: ['sh', '-c', 'cadence-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} || true']
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+          {{- if eq (include "cadence.persistence.sql.driver" (list $ $store)) "mysql" }}
+          # args: ["cadence-sql-tool", "create", "--db", "{{ $storeConfig.sql.database }}"]
+          args: ['sh', '-c', 'cadence-sql-tool create --db {{ $storeConfig.sql.database }} || true']
+          {{- end }}
+          {{- end }}
+          env:
+            - name: PATH
+              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              value: {{ $storeConfig.cassandra.password }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_DRIVER
+              value: {{ include "cadence.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- end }}
+        {{- end }}
+        {{- else }}
+          []
+        {{- end }}
+      containers:
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          args: ["cadence-{{ include "cadence.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-v", "0.0"]
+          env:
+            - name: PATH
+              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              value: {{ $storeConfig.cassandra.password }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_DRIVER
+              value: {{ include "cadence.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- end }}
+        {{- end }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cadence.fullname" . }}-schema-update
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+    "helm.sh/hook": post-install,pre-upgrade
+    {{- else }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      name: {{ include "cadence.fullname" . | trunc 42 | trimSuffix "-" }}-schema-update
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      restartPolicy: "OnFailure"
+      initContainers:
+        {{- if .Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        {{- else if .Values.mysql.enabled }}
+        - name: check-mysql-service
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ .Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- else }}
+          []
+        {{- end }}
+      containers:
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: {{ $store }}-schema
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+          # args: ["cadence-cassandra-tool", "update-schema", "-d", "/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned || true']
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+          {{- if eq (include "cadence.persistence.sql.driver" (list $ $store)) "mysql" }}
+          # args: ["cadence-sql-tool", "update-schema", "-d", "/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned || true']
+          {{- end }}
+          {{- end }}
+          env:
+            - name: PATH
+              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              value: {{ $storeConfig.cassandra.password }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_DRIVER
+              value: {{ include "cadence.persistence.sql.driver" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- end }}
+        {{- end }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -68,8 +68,6 @@ spec:
           {{- end }}
           {{- end }}
           env:
-            - name: PATH
-              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.schema.setup }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -146,6 +147,8 @@ spec:
         {{- end }}
 
 ---
+{{- end }}
+{{- if .Values.schema.update }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -250,3 +253,4 @@ spec:
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
             {{- end }}
         {{- end }}
+{{- end }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -58,12 +58,12 @@ spec:
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
           # args: ["cadence-cassandra-tool", "create", "-k", "{{ $storeConfig.cassandra.keyspace }}"]
-          args: ['sh', '-c', 'cadence-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }} || true']
+          args: ['sh', '-c', 'cadence-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }}']
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
           {{- if eq (include "cadence.persistence.sql.driver" (list $ $store)) "mysql" }}
           # args: ["cadence-sql-tool", "create", "--db", "{{ $storeConfig.sql.database }}"]
-          args: ['sh', '-c', 'cadence-sql-tool create --db {{ $storeConfig.sql.database }} || true']
+          args: ['sh', '-c', 'cadence-sql-tool create --db {{ $storeConfig.sql.database }}']
           {{- end }}
           {{- end }}
           env:
@@ -208,12 +208,12 @@ spec:
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
           # args: ["cadence-cassandra-tool", "update-schema", "-d", "/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned"]
-          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned || true']
+          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned']
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
           {{- if eq (include "cadence.persistence.sql.driver" (list $ $store)) "mysql" }}
           # args: ["cadence-sql-tool", "update-schema", "-d", "/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
-          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned || true']
+          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned']
           {{- end }}
           {{- end }}
           env:

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -112,8 +112,6 @@ spec:
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           args: ["cadence-{{ include "cadence.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-v", "0.0"]
           env:
-            - name: PATH
-              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
@@ -210,18 +208,16 @@ spec:
           image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
-          # args: ["cadence-cassandra-tool", "update-schema", "-d", "/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned"]
-          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned']
+          # args: ["cadence-cassandra-tool", "update-schema", "-d", "/etc/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned']
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
           {{- if eq (include "cadence.persistence.sql.driver" (list $ $store)) "mysql" }}
-          # args: ["cadence-sql-tool", "update-schema", "-d", "/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
-          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned']
+          # args: ["cadence-sql-tool", "update-schema", "-d", "/etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned']
           {{- end }}
           {{- end }}
           env:
-            - name: PATH
-              value: "/cadence:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}

--- a/cadence/templates/server-secret.yaml
+++ b/cadence/templates/server-secret.yaml
@@ -1,7 +1,7 @@
 {{- range $store := (list "default" "visibility") }}
 {{- $storeConfig := index $.Values.server.config.persistence $store }}
 {{- $driverConfig := index $storeConfig (include "cadence.persistence.driver" (list $ $store)) }}
-{{- $secretName := printf "%s-%s-store" (include "cadence.fullname" $) $store }}
+{{- $secretName := include "cadence.componentname" (list $ (printf "%s-store" $store)) }}
 {{- if and (not $driverConfig.existingSecret) (eq (include "cadence.persistence.secretName" (list $ $store)) $secretName) }}
 ---
 apiVersion: v1

--- a/cadence/templates/server-secret.yaml
+++ b/cadence/templates/server-secret.yaml
@@ -1,0 +1,26 @@
+{{- range $store := (list "default" "visibility") }}
+{{- $storeConfig := index $.Values.server.config.persistence $store }}
+{{- $driverConfig := index $storeConfig (include "cadence.persistence.driver" (list $ $store)) }}
+{{- $secretName := printf "%s-%s-store" (include "cadence.fullname" $) $store }}
+{{- if and (not $driverConfig.existingSecret) (eq (include "cadence.persistence.secretName" (list $ $store)) $secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+type: Opaque
+data:
+  {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+  password: {{ $storeConfig.cassandra.password | b64enc | quote }}
+  {{- else if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+  password: {{ include "cadence.persistence.sql.password" (list $ $store) | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/cadence/templates/server-service.yaml
+++ b/cadence/templates/server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cadence.fullname" . }}-frontend
+  name: {{ include "cadence.componentname" (list . "frontend") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
@@ -28,7 +28,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cadence.fullname" $ }}-{{ $service }}-headless
+  name: {{ include "cadence.componentname" (list $ (printf "%s-headless" $service)) }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" $ }}
     helm.sh/chart: {{ include "cadence.chart" $ }}

--- a/cadence/templates/server-service.yaml
+++ b/cadence/templates/server-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.server.frontend.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,89 +5,57 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
 spec:
   type: {{ .Values.server.frontend.service.type }}
   ports:
     - port: {{ .Values.server.frontend.service.port }}
-      targetPort: {{ .Values.server.frontend.service.port }}
+      targetPort: rpc
       protocol: TCP
-      name: frontend
+      name: rpc
   selector:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+    app.kubernetes.io/component: frontend
 
 ---
-
-{{- if .Values.server.matching.enabled -}}
+{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cadence.fullname" . }}-matching
+  name: {{ include "cadence.fullname" $ }}-{{ $service }}-headless
   labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+  annotations:
+    # Use this annotation in addition to the actual field below because the
+    # annotation will stop being respected soon but the field is broken in
+    # some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  type: {{ .Values.server.matching.service.type }}
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
-    - port: {{ .Values.server.matching.service.port }}
-      targetPort: {{ .Values.server.matching.service.port }}
+    - port: {{ $serviceValues.service.port }}
+      targetPort: rpc
       protocol: TCP
-      name: matching
+      name: rpc
   selector:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $service }}
 
 ---
-
-{{- if .Values.server.history.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "cadence.fullname" . }}-history
-  labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-spec:
-  type: {{ .Values.server.history.service.type }}
-  ports:
-    - port: {{ .Values.server.history.service.port }}
-      targetPort: {{ .Values.server.history.service.port }}
-      protocol: TCP
-      name: history
-  selector:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
----
-
-{{- if .Values.server.worker.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "cadence.fullname" . }}-worker
-  labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-spec:
-  type: {{ .Values.server.worker.service.type }}
-  ports:
-    - port: {{ .Values.server.worker.service.port }}
-      targetPort: {{ .Values.server.worker.service.port }}
-      protocol: TCP
-      name: worker
-  selector:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-

--- a/cadence/templates/web-deployment.yaml
+++ b/cadence/templates/web-deployment.yaml
@@ -4,28 +4,35 @@ kind: Deployment
 metadata:
   name: {{ include "cadence.fullname" . }}-web
   labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+      app.kubernetes.io/name: {{ include "cadence.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: web
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
     spec:
-
       initContainers:
       - name: check-frontend
         image: "banzaicloud/tcheck:latest"
         command: ['sh', '-c', 'until tcheck --peer {{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }} --serviceName cadence-frontend; do echo waiting for frontend; sleep 2; done;']
-
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
@@ -41,11 +48,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 8088
+              port: http
           readinessProbe:
             httpGet:
               path: /
-              port: 8088
+              port: http
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
       {{- with .Values.web.nodeSelector }}

--- a/cadence/templates/web-deployment.yaml
+++ b/cadence/templates/web-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cadence.fullname" . }}-web
+  name: {{ include "cadence.componentname" (list . "web") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}

--- a/cadence/templates/web-ingress.yaml
+++ b/cadence/templates/web-ingress.yaml
@@ -1,15 +1,18 @@
 {{- if .Values.web.ingress.enabled -}}
-{{- $serviceName := include "cadence.fullname" . -}}
+{{- $serviceName := include "cadence.fullname" . -}}-web
 {{- $servicePort := .Values.web.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "cadence.fullname" . }}-web
   labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
 {{- with .Values.web.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/cadence/templates/web-ingress.yaml
+++ b/cadence/templates/web-ingress.yaml
@@ -4,7 +4,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "cadence.fullname" . }}-web
+  name: {{ include "cadence.componentname" (list . "web") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}

--- a/cadence/templates/web-service.yaml
+++ b/cadence/templates/web-service.yaml
@@ -4,13 +4,16 @@ kind: Service
 metadata:
   name: {{ include "cadence.fullname" . }}-web
   labels:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
 {{- with .Values.web.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | indent 4 }}
 {{- end }}
 spec:
 {{- with .Values.web.service.loadBalancerIP }}
@@ -19,10 +22,11 @@ spec:
   type: {{ .Values.web.service.type }}
   ports:
     - port: {{ .Values.web.service.port }}
-      targetPort: 8088
+      targetPort: http
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "cadence.name" . }}-web
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: web
 {{- end }}

--- a/cadence/templates/web-service.yaml
+++ b/cadence/templates/web-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cadence.fullname" . }}-web
+  name: {{ include "cadence.componentname" (list . "web") }}
   labels:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     helm.sh/chart: {{ include "cadence.chart" . }}

--- a/cadence/values.dev.yaml
+++ b/cadence/values.dev.yaml
@@ -1,3 +1,13 @@
+server:
+  image:
+    # repository: ubercadence/server
+    # repository: banzaicloud/cadence-server
+    repository: ubercadence/longer
+    tag: 0.5.10
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+
 cassandra:
   enabled: true
   livenessProbe:

--- a/cadence/values.dev.yaml
+++ b/cadence/values.dev.yaml
@@ -1,9 +1,4 @@
 server:
-  image:
-    # repository: ubercadence/server
-    # repository: banzaicloud/cadence-server
-    repository: ubercadence/longer
-    tag: 0.5.10
   podAnnotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9090'

--- a/cadence/values.dev.yaml
+++ b/cadence/values.dev.yaml
@@ -1,0 +1,17 @@
+cassandra:
+  enabled: true
+  livenessProbe:
+    initialDelaySeconds: 0
+  readinessProbe:
+    initialDelaySeconds: 0
+  config:
+    num_tokens: 0
+    max_heap_size: 512M
+    heap_new_size: 128M
+    seed_size: 0
+  env:
+    JVM_OPTS: |-
+      -Dcassandra.skip_wait_for_gossip_to_settle=0
+      -Dcassandra.initial_token=0
+    persistence:
+      enabled: true

--- a/cadence/values.prod.yaml
+++ b/cadence/values.prod.yaml
@@ -1,0 +1,54 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+
+  config:
+    persistence:
+      default:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence
+          consistency: One
+          user: ""
+          password: ""
+
+        sql:
+          driver: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence
+          user: ""
+          password: ""
+
+      visibility:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence_visibility
+          consistency: One
+          user: ""
+          password: ""
+
+        sql:
+          driver: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence_visibility
+          user: ""
+          password: ""
+
+schema:
+  setup: false
+  update: false
+
+cassandra:
+  enabled: false
+
+mysql:
+  enabled: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -33,7 +33,10 @@ server:
 
   config:
     logLevel: "debug,info"
+
+    # IMPORTANT: This value cannot be changed, once it's set.
     numHistoryShards: 1000
+
     persistence:
       default:
         driver: "" # cassandra or sql

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 server:
   image:
     repository: ubercadence/server
-    tag: 0.6.0
+    tag: 0.7.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -48,6 +48,7 @@ server:
           consistency: One
           user: ""
           password: ""
+          existingSecret: ""
 
         sql:
           driver: "" # mysql
@@ -56,6 +57,7 @@ server:
           database: cadence
           user: ""
           password: ""
+          existingSecret: ""
 
       visibility:
         driver: "" # cassandra or sql
@@ -67,6 +69,7 @@ server:
           consistency: One
           user: ""
           password: ""
+          existingSecret: ""
 
         sql:
           driver: "" # mysql
@@ -75,6 +78,7 @@ server:
           database: cadence_visibility
           user: ""
           password: ""
+          existingSecret: ""
 
   frontend:
     # replicaCount: 1
@@ -139,7 +143,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: 3.3.1
+    tag: 3.3.2
     pullPolicy: IfNotPresent
 
   service:
@@ -203,8 +207,6 @@ mysql:
   service:
     port: 3306
   mysqlUser: cadence
-  # TODO: support secrets
-  mysqlPassword: cadence
   initializationFiles:
     user.sql: |-
       GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -3,9 +3,8 @@ fullnameOverride: ""
 
 server:
   image:
-    # repository: ubercadence/server
-    repository: banzaicloud/cadence-server
-    tag: 0.5.9
+    repository: ubercadence/server
+    tag: 0.6.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -1,79 +1,22 @@
-# Default values for cadence.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+nameOverride: ""
+fullnameOverride: ""
 
 server:
-  replicaCount: 1
-
   image:
-    repository: ubercadence/server
-    tag: 0.5.8
+    # repository: ubercadence/server
+    repository: banzaicloud/cadence-server
+    tag: 0.5.9
     pullPolicy: IfNotPresent
 
-  logLevel: "debug,info"
-
-  nameOverride: ""
-  fullnameOverride: ""
-
-
-  bindOnLocalHost: false
-
-  cassandraVisibilityKeyspace: cadence
-
-  frontend:
-    enabled: true
-    bindOnIP: "0.0.0.0"
-    service:
-      type: ClusterIP
-      port: 7933
+  # Global default settings (can be overridden per service)
+  replicaCount: 1
+  metrics:
     prometheus:
-      timerType: "histogram"
-      port: 8000
-
-  matching:
-    enabled: true
-    bindOnIP: "0.0.0.0"
-    service:
-      type: ClusterIP
-      port: 7935
-    prometheus:
-      timerType: "histogram"
-      port: 8001
-
-  history:
-    enabled: true
-    bindOnIP: "0.0.0.0"
-    numHistoryShards: 4
-    service:
-      type: ClusterIP
-      port: 7934
-    prometheus:
-      timerType: "histogram"
-      port: 8002
-
-  worker:
-    enabled: true
-    bindOnIP: "0.0.0.0"
-    service:
-      type: ClusterIP
-      port: 7939
-    prometheus:
-      timerType: "histogram"
-      port: 8003
-
-  ingress:
-    enabled: false
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    paths: []
-    hosts:
-      - chart-example.local
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-
+      timerType: histogram
+  podAnnotations: {}
+    # Annotation to enable Prometheus scrape functionality.
+    # prometheus.io/scrape: 'true'
+    # prometheus.io/port: '9090'
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -85,16 +28,107 @@ server:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
 
-  annotations: {}
-    # Annotation to enable Prometheus scrape functionality.
-    # prometheus.io/scrape: 'true'
+  config:
+    logLevel: "debug,info"
+    numHistoryShards: 4
+    persistence:
+      default:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence
+          consistency: One
+          user: ""
+          password: ""
+
+        sql:
+          driver: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence
+          user: ""
+          password: ""
+
+      visibility:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence_visibility
+          consistency: One
+          user: ""
+          password: ""
+
+        sql:
+          driver: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence_visibility
+          user: ""
+          password: ""
+
+  frontend:
+    # replicaCount: 1
+    service:
+      type: ClusterIP
+      port: 7933
+    metrics:
+      prometheus: {}
+        # timerType: histogram
+    podAnnotations: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  history:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      port: 7934
+    metrics:
+      prometheus: {}
+        # timerType: histogram
+    podAnnotations: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  matching:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      port: 7935
+    metrics:
+      prometheus: {}
+        # timerType: histogram
+    podAnnotations: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  worker:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      port: 7939
+    metrics:
+      prometheus: {}
+        # timerType: histogram
+    podAnnotations: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
 
 web:
   enabled: true
@@ -103,13 +137,8 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: 3.1.2
+    tag: 3.3.1
     pullPolicy: IfNotPresent
-
-  cadenceTchannelPeers: cadence:7933
-
-  nameOverride: ""
-  fullnameOverride: ""
 
   service:
     type: ClusterIP
@@ -153,22 +182,24 @@ web:
 
 
 cassandra:
+  enabled: true
   image:
     repo: cassandra
     tag: 3.11.3
     pullPolicy: IfNotPresent
-  enabled: true
-  seeds: cassandra
-  consistency: One
-  keyspace: cadence
   config:
     cluster_size: 1
-  resources: {}
-    # requests:
-    #   memory: 4Gi
-    #   cpu: 1
-    # limits:
-    #   cpu: 2
-  # podDisruptionBudget:
-  #   maxUnavailable: 1
-    # minAvailable: 1
+    ports:
+      cql: 9042
+
+mysql:
+  enabled: false
+  imageTag: "5.7.26"
+  service:
+    port: 3306
+  mysqlUser: cadence
+  # TODO: support secrets
+  mysqlPassword: cadence
+  initializationFiles:
+    user.sql: |-
+      GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -34,7 +34,7 @@ server:
 
   config:
     logLevel: "debug,info"
-    numHistoryShards: 4
+    numHistoryShards: 1000
     persistence:
       default:
         driver: "" # cassandra or sql

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -35,7 +35,7 @@ server:
     logLevel: "debug,info"
 
     # IMPORTANT: This value cannot be changed, once it's set.
-    numHistoryShards: 1000
+    numHistoryShards: 512
 
     persistence:
       default:

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -182,6 +182,9 @@ web:
 
   affinity: {}
 
+schema:
+  setup: true
+  update: true
 
 cassandra:
   enabled: true

--- a/cadence/values/cassandra.yaml
+++ b/cadence/values/cassandra.yaml
@@ -1,0 +1,18 @@
+image:
+  tag: 3.11.3
+livenessProbe:
+  initialDelaySeconds: 0
+readinessProbe:
+  initialDelaySeconds: 0
+config:
+  cluster_size: 1
+  num_tokens: 0
+  max_heap_size: 512M
+  heap_new_size: 128M
+  seed_size: 0
+env:
+  JVM_OPTS: |-
+    -Dcassandra.skip_wait_for_gossip_to_settle=0
+    -Dcassandra.initial_token=0
+  persistence:
+    enabled: true

--- a/cadence/values/mysql.yaml
+++ b/cadence/values/mysql.yaml
@@ -1,0 +1,10 @@
+  imageTag: "5.7.26"
+  mysqlUser: cadence
+  mysqlPassword: cadence
+  initializationFiles:
+    cadence.sql: |-
+      CREATE DATABASE IF NOT EXISTS cadence;
+      GRANT ALL PRIVILEGES ON cadence.* TO 'cadence'@'%';
+
+      CREATE DATABASE IF NOT EXISTS cadence_visibility;
+      GRANT ALL PRIVILEGES ON cadence_visibility.* TO 'cadence'@'%';

--- a/cadence/values/values.cassandra.yaml
+++ b/cadence/values/values.cassandra.yaml
@@ -1,0 +1,31 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "cadence"
+          consistency: "One"
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+      visibility:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "cadence_visibility"
+          consistency: "One"
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+cassandra:
+  enabled: false

--- a/cadence/values/values.mysql.yaml
+++ b/cadence/values/values.mysql.yaml
@@ -1,0 +1,27 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "sql"
+
+        sql:
+          driver: "mysql"
+          host: "mysql"
+          port: 3306
+          database: cadence
+          user: "cadence"
+          password: "cadence"
+
+      visibility:
+        driver: "sql"
+
+        sql:
+          driver: "mysql"
+          host: "mysql"
+          port: 3306
+          database: cadence_visibility
+          user: "cadence"
+          password: "cadence"
+
+cassandra:
+  enabled: false

--- a/cadence/values/values.prom.yaml
+++ b/cadence/values/values.prom.yaml
@@ -1,0 +1,4 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'


### PR DESCRIPTION
This PR is a major rewrite of the Cadence server Helm chart:

- Server services can be scaled independently
- Cluster bootstrap happens via headless services
- Prometheus scrape support
- External Cassandra support
- MySQL support
- External MySQL support


#### TODO

~~- Better secret support (currently there is none)~~
~~- Make schema migrations optional~~
- Service monitor (in subsequent PR)