### PR TITLE
fix hardcoded image in vault chart

### DIFF
--- a/vault/Chart.yaml
+++ b/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.7
+version: 0.6.8
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/vault/templates/statefulset.yaml
+++ b/vault/templates/statefulset.yaml
@@ -26,8 +26,8 @@ spec:
     spec:
       initContainers:
       - name: vault-config
-        image: "jwilder/dockerize:latest"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.dockerizeImage.repository }}:{{ .Values.dockerizeImage.tag }}"
+        imagePullPolicy: {{ .Values.dockerizeImage.pullPolicy }}
         args:
           - "-delims"
           - "[[:]]"
@@ -214,8 +214,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: prometheus-statsd-exporter
-        image: "prom/statsd-exporter:latest"
-        imagePullPolicy: IfNotPresent
+        image: "{{ .Values.statsd.image.repository }}:{{ .Values.statsd.image.tag }}"
+        imagePullPolicy: {{ .Values.statsd.image.pullPolicy }}
         args: ["--statsd.mapping-config=/tmp/statsd-mapping.conf"]
         ports:
         - containerPort: {{ .Values.statsd.metrics.port }}

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -8,6 +8,10 @@ image:
   repository: vault
   tag: 1.1.2
   pullPolicy: IfNotPresent
+dockerizeImage:
+  repository: jwilder/dockerize
+  tag: latest
+  pullPolicy: IfNotPresent
 service:
   name: vault
   type: ClusterIP
@@ -186,6 +190,10 @@ unsealer:
       prometheus.io/port: "9091"
 
 statsd:
+  image:
+    repository: prom/statsd-exporter
+    tag: latest
+    pullPolicy: IfNotPresent
   metrics:
     enabled: true
     port: 9102


### PR DESCRIPTION
Hi,

As i'm using a private repository to store docker images, it's impossible to use some of your chart that have hardcoded image names in YAML templates.

Here is a small PR to fix the vault chart.