### PR TITLE
[vault] fix values.yaml typo

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -77,7 +77,7 @@ vault:
   # passing a MySQL secret. The three fields required are a secretName indicating
   # the name of the Kuberentes secret (created outside of this chart), secretKey
   # in this secret and envName which will be the name of the env var in the containers.
-  secretEnvs: []
+  envSecrets: []
     # - secretName: mysql
     #   secretKey: mysql-username
     #   envName: "MYSQL_USERNAME"


### PR DESCRIPTION
The following value is listed in the example values.yaml but isn't referenced in any of the templates: https://github.com/banzaicloud/banzai-charts/blob/dd483504fbd566246d4fcc87af4d8c5723b6320d/vault/values.yaml#L80

Meanwhile README.md and templates/statefulset.yaml mention `envSecrets`:
https://github.com/banzaicloud/banzai-charts/blob/dd483504fbd566246d4fcc87af4d8c5723b6320d/vault/templates/statefulset.yaml#L45

https://github.com/banzaicloud/banzai-charts/blob/dd483504fbd566246d4fcc87af4d8c5723b6320d/vault/README.md#L125

I suspect this is a typo in values.yaml.

Fixes #884