### PR TITLE
vault-secrets-webhook: define readinessProbe

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.17"
+appVersion: "0.4.18"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.19
+version: 0.3.20
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -15,7 +15,7 @@ The namespace must have a label of `name` with the namespace name as it's value.
 set the target namespace name or skip for the default name: vswh
 
 ```bash
-export WEBHOOK_NS=`<namepsace>`
+export WEBHOOK_NS=`<namespace>`
 ```
 
 ```bash
@@ -54,7 +54,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 |replicaCount                         |number of replicas                                 |1                                         |
 |resources                            |resources to request                               |{}                                        |
 |service.externalPort                 |webhook service external port                      |443                                       |
-|service.internalPort                 |webhook service external port                      |443                                       |
+|service.internalPort                 |webhook service external port                      |8443                                       |
 |service.name                         |webhook service name                               |vault-secrets-webhook                     |
 |service.type                         |webhook service type                               |ClusterIP                                 |
 |tolerations                          |tolerations to add                                 |[]                                        |

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -58,7 +58,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 |service.name                         |webhook service name                               |vault-secrets-webhook                     |
 |service.type                         |webhook service type                               |ClusterIP                                 |
 |tolerations                          |tolerations to add                                 |[]                                        |
-|rabc.enabled                         |use rbac                                           |true                                      |
-|rabc.psp.enabled                     |use pod security policy                            |false                                     |
+|rbac.enabled                         |use rbac                                           |true                                      |
+|rbac.psp.enabled                     |use pod security policy                            |false                                     |
 |env.VAULT_IMAGE                      |vault image                                        |vault:latest                              |
 |env.VAULT_ENV_IMAGE                  |vault-env image                                    |banzaicloud/vault-env:latest              |

--- a/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -49,6 +49,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: {{ .Values.service.internalPort }}
           volumeMounts:
           - mountPath: /var/serving-cert
             name: serving-cert

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -8,7 +8,7 @@ debug: false
 
 image:
   repository: banzaicloud/vault-secrets-webhook
-  tag: 0.4.17
+  tag: 0.4.18
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
If there is no `readinessProbe` defined for the Deployments the Helm `--wait` flag is just a best-effort mechanism, we hadn't got any, not even on application level (fixed by https://github.com/banzaicloud/bank-vaults/pull/553), so this PR fixes that.

Fixes: https://github.com/banzaicloud/banzai-charts/issues/888