### PR TITLE
vault-secrets-webhook: make ConfigMap mutation optional

### DIFF
--- a/vault-secrets-webhook/Chart.yaml
+++ b/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.18"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.22
+version: 0.3.23
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/vault-secrets-webhook/README.md
+++ b/vault-secrets-webhook/README.md
@@ -69,3 +69,4 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | env.VAULT_ENV_IMAGE    | vault-env image                                     | banzaicloud/vault-env:latest      |
 | volumes                | extra volume definitions                            | []                                |
 | volumeMounts           | extra volume mounts                                 | []                                |
+| configMapMutation      | enable injecting values from Vault to ConfigMaps    | false                             |

--- a/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -85,6 +85,7 @@ items:
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
+{{- if .Values.configMapMutation }}
   - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
     clientConfig:
       service:
@@ -116,3 +117,4 @@ items:
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
+{{- end }}

--- a/vault-secrets-webhook/values.yaml
+++ b/vault-secrets-webhook/values.yaml
@@ -46,3 +46,6 @@ rbac:
   enabled: true
   psp:
     enabled: false
+
+# This can cause issues when used with Helm, so it is not enabled by default
+configMapMutation: false


### PR DESCRIPTION
ConfigMap mutation might cause issues during Helm installs, so enable it only on your own responsibility.