### PR TITLE
Update Store Deployment Spec

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.1.0
 description: A Helm chart for Thanos for Prometheus long term storage
 name: thanos
-version: 0.2.1
+version: 0.2.2
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  serviceName: {{ include "thanos.name" . }}-store
   replicas: {{ .Values.store.replicaCount}}
   selector:
     matchLabels:


### PR DESCRIPTION
Store Deployment spec had `serviceName`, which is not a part of [DeploymentSpec apps/v1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentspec-v1-apps) but [StatefulSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#statefulset-v1-apps). This caused issues with latest versions of kubectl which validates manifest