### PR TITLE
circleci: remove context from lint-chart job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ workflows:
   static-checks:
     jobs:
       - helm/lint-chart:
-          context: helm
           charts-dir: '.'
           add-extra-repositories: *helm_repositories
           filters:


### PR DESCRIPTION
Remove unnecessary context to allow linting of pull requests from members
outside github organization.