### PR TITLE
Adding option to mount cert to /etc/certs from existing secret name

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.1.0
 description: A Helm chart for Thanos for Prometheus long term storage
 name: thanos
-version: 0.2.1
+version: 0.2.5
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -39,6 +39,7 @@ helm install banzaicloud-stable/thanos --set objstore.bucketName="test-bucket" -
 | store.logLevel | Log level | debug |
 | store.resources | Resources of the pods | {} |
 | store.securityContext | Manage securityContext of store pods | {} |
+| store.certSecretName  | Existing secret name with TLS certs mount to the /etc/certs path  |  "" |
 | query.replicaCount | Pod replica count| 1 |
 | query.monitoring.enabled | | true |
 | query.http.port | Enable http port (includes /metrics) | 10901 |
@@ -46,7 +47,7 @@ helm install banzaicloud-stable/thanos --set objstore.bucketName="test-bucket" -
 | query.logLevel | Log level| debug |
 | query.resources | Resources of the pods | {} |
 | query.securityContext | Manage securityContext of query pods | {} |
-| query.certSecretName  | Secret name to mount a secret with TLS cert to the /etc/certs path  |  "" |
+| query.certSecretName  | Existing secret name with TLS certs mount to the /etc/certs path |  "" |
 | compact.monitoring.enabled | Enable prometheus scraping endpoint | true |
 | compact.http.port | Enable http port (includes /metrics) | 10902 |
 | compact.logLevel | Log level | DEBUG |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -46,6 +46,7 @@ helm install banzaicloud-stable/thanos --set objstore.bucketName="test-bucket" -
 | query.logLevel | Log level| debug |
 | query.resources | Resources of the pods | {} |
 | query.securityContext | Manage securityContext of query pods | {} |
+| query.certSecretName  | Secret name to mount a secret with TLS cert to the /etc/certs path  |  "" |
 | compact.monitoring.enabled | Enable prometheus scraping endpoint | true |
 | compact.http.port | Enable http port (includes /metrics) | 10902 |
 | compact.logLevel | Log level | DEBUG |

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -51,6 +51,9 @@ spec:
         - "--sync-delay=30m"
         - "--data-dir=/var/thanos/store"
         - "--wait"
+        {{- range $key, $value := .Values.compact.extraArgs }}
+        - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+        {{- end }}
         ports:
         - name: monitoring
           containerPort: {{ .Values.compact.http.port }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -51,9 +51,6 @@ spec:
         - "--sync-delay=30m"
         - "--data-dir=/var/thanos/store"
         - "--wait"
-        {{- range $key, $value := .Values.compact.extraArgs }}
-        - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
-        {{- end }}
         ports:
         - name: monitoring
           containerPort: {{ .Values.compact.http.port }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -61,6 +61,7 @@ spec:
         - mountPath: /etc/certs
           name: {{ .Values.query.certSecretName }}
           readOnly: true
+        {{- end }}
         {{- if .Values.query.livenessProbe }}
         livenessProbe:
           {{ toYaml .Values.query.livenessProbe | nindent 10 }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -53,6 +53,19 @@ spec:
           containerPort: {{ .Values.cluster.port }}
         resources:
           {{ toYaml .Values.query.resources | nindent 10 }}
+        {{- if .Values.query.certSecretName }}
+        volumeMounts:
+        - mountPath: /etc/certs
+          name: {{ .Values.query.certSecretName }}
+          readOnly: true
+        {{- end }}
       securityContext:
         {{ toYaml .Values.query.securityContext | nindent 8 }}
+      {{- if .Values.query.certSecretName }}
+      volumes:
+      - name: {{ .Values.query.certSecretName }}
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.query.certSecretName }}
+      {{- end }}
 {{ end }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -44,9 +44,6 @@ spec:
         - "--cluster.peers={{ include "thanos.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.cluster.port }}"
         - "--query.replica-label={{ .Values.replicaLabelName }}"
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
-        {{- range $key, $value := .Values.query.extraArgs }}
-        - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
-        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.query.http.port}}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - "--cluster.peers={{ include "thanos.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.cluster.port }}"
         - "--query.replica-label={{ .Values.replicaLabelName }}"
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
+        {{- range $key, $value := .Values.query.extraArgs }}
+        - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.query.http.port}}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -67,6 +67,11 @@ spec:
         {{- end }}
         - name: data
           mountPath: /var/thanos/store
+        {{- if .Values.store.certSecretName }}
+        - mountPath: /etc/certs
+          name: {{ .Values.store.certSecretName }}
+          readOnly: true
+        {{- end }}
         resources:
           {{ toYaml .Values.store.resources | nindent 10 }}
       volumes:
@@ -84,6 +89,12 @@ spec:
             - key: google.json
               path: google.json
     {{- end }}
+      {{- if .Values.store.certSecretName }}
+      - name: {{ .Values.store.certSecretName }}
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.store.certSecretName }}
+      {{- end }}
       securityContext:
         {{ toYaml .Values.store.securityContext | nindent 8 }}
 {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -45,6 +45,7 @@ query:
     #      - chart-example.local
 
   securityContext: {}
+  certSecretName: ""
 
 compact:
   enabled: true

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -16,6 +16,7 @@ store:
   logLevel: debug
   securityContext: {}
   resources: {}
+  certSecretName: ""
 
 query:
   enabled: true

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -30,7 +30,6 @@ query:
     port: 10902
   logLevel: debug
   resources: {}
-  extraArgs: {}
   livenessProbe: {}
     # httpGet:
     #   path: /-/healthy
@@ -67,7 +66,6 @@ compact:
   logLevel: debug
   securityContext: {}
   resources: {}
-  extraArgs: {}
   dataVolume:
     name: data
     backend: {}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -30,6 +30,7 @@ query:
     port: 10902
   logLevel: debug
   resources: {}
+  extraArgs: {}
 
   ingress:
     enabled: false
@@ -58,6 +59,7 @@ compact:
   logLevel: debug
   securityContext: {}
   resources: {}
+  extraArgs: {}
 
 cluster:
   address: 0.0.0.0


### PR DESCRIPTION
Thanos store and query component support providing TLS certs. 
To make use of this feature I added the option to mount an existing secret to the /etc/certs path.