### PR TITLE
Use toYaml for Cadence persistence config

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.7.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -25,18 +25,9 @@ data:
           cassandra:
             hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "default") }}
             port: {{ include "cadence.persistence.cassandra.port" (list . "default") }}
-            keyspace: {{ .Values.server.config.persistence.default.cassandra.keyspace }}
-            consistency: {{ .Values.server.config.persistence.default.cassandra.consistency }}
-            user: {{ .Values.server.config.persistence.default.cassandra.user }}
             password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
-            {{- if .Values.server.config.persistence.default.cassandra.datacenter }}
-            datacenter: {{ .Values.server.config.persistence.default.cassandra.datacenter | quote }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.cassandra.maxQPS }}
-            maxQPS: {{ .Values.server.config.persistence.default.cassandra.maxQPS }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.cassandra.maxConns }}
-            maxConns: {{ .Values.server.config.persistence.default.cassandra.maxConns }}
+            {{- with (omit .Values.server.config.persistence.default.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list . "default")) "sql" }}
@@ -47,21 +38,8 @@ data:
             connectProtocol: "tcp"
             user: {{ include "cadence.persistence.sql.user" (list . "default") }}
             password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
-            {{- if .Values.server.config.persistence.default.sql.maxConns }}
-            maxConns: {{ .Values.server.config.persistence.default.sql.maxConns }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.sql.maxIdleConns }}
-            maxIdleConns: {{ .Values.server.config.persistence.default.sql.maxIdleConns }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.sql.maxConnLifetime }}
-            maxConnLifetime: {{ .Values.server.config.persistence.default.sql.maxConnLifetime | quote }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.sql.maxQPS }}
-            maxQPS: {{ .Values.server.config.persistence.default.sql.maxQPS }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.default.sql.connectAttributes }}
-            connectAttributes:
-            {{- toYaml .Values.server.config.persistence.default.sql.connectAttributes | nindent 14 }}
+            {{- with (omit .Values.server.config.persistence.default.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
         visibility:
@@ -69,18 +47,9 @@ data:
           cassandra:
             hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "visibility") }}
             port: {{ include "cadence.persistence.cassandra.port" (list . "visibility") }}
-            keyspace: {{ .Values.server.config.persistence.visibility.cassandra.keyspace }}
-            consistency: {{ .Values.server.config.persistence.visibility.cassandra.consistency }}
-            user: {{ .Values.server.config.persistence.visibility.cassandra.user }}
             password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
-            {{- if .Values.server.config.persistence.visibility.cassandra.datacenter }}
-            datacenter: {{ .Values.server.config.persistence.visibility.cassandra.datacenter | quote }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.cassandra.maxQPS }}
-            maxQPS: {{ .Values.server.config.persistence.visibility.cassandra.maxQPS }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.cassandra.maxConns }}
-            maxConns: {{ .Values.server.config.persistence.visibility.cassandra.maxConns }}
+            {{- with (omit .Values.server.config.persistence.visibility.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "sql" }}
@@ -91,21 +60,8 @@ data:
             connectProtocol: "tcp"
             user: {{ include "cadence.persistence.sql.user" (list . "visibility") }}
             password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
-            {{- if .Values.server.config.persistence.visibility.sql.maxConns }}
-            maxConns: {{ .Values.server.config.persistence.visibility.sql.maxConns }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.sql.maxIdleConns }}
-            maxIdleConns: {{ .Values.server.config.persistence.visibility.sql.maxIdleConns }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.sql.maxConnLifetime }}
-            maxConnLifetime: {{ .Values.server.config.persistence.visibility.sql.maxConnLifetime | quote }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.sql.maxQPS }}
-            maxQPS: {{ .Values.server.config.persistence.visibility.sql.maxQPS }}
-            {{- end }}
-            {{- if .Values.server.config.persistence.visibility.sql.connectAttributes }}
-            connectAttributes:
-            {{- toYaml .Values.server.config.persistence.visibility.sql.connectAttributes | nindent 14 }}
+            {{- with (omit .Values.server.config.persistence.visibility.sql "driver" "driverName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
 

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -45,10 +45,10 @@ server:
           hosts: []
           # port: 9042
           keyspace: cadence
-          consistency: One
           user: ""
           password: ""
           existingSecret: ""
+          consistency: One
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2
@@ -75,10 +75,10 @@ server:
           hosts: []
           # port: 9042
           keyspace: cadence_visibility
-          consistency: One
           user: ""
           password: ""
           existingSecret: ""
+          consistency: One
           # datacenter: "us-east-1a"
           # maxQPS: 1000
           # maxConns: 2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

In order to avoid hardcoding config options, this PR replaces most of the persistence config options with `toYaml`.

### Additional context

This could be further improved by using a template for the entire store part in a subsequent PR.