### PR TITLE
Bump anchore-image validator version

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.4.2
-appVersion: 0.3.3
+version: 0.4.3
+appVersion: 0.3.4
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,7 +5,7 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.3.3
+  tag: 0.3.4
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related PR | https://github.com/banzaicloud/anchore-image-validator/pull/36
| License         | Apache 2.0


### What's in this PR?
Bump anchore-image-validator version due to cluster scope fix

Merge after: https://github.com/banzaicloud/anchore-image-validator/pull/36 and it's tagged to 0.3.4.
