### PR TITLE
[thanos] Add support for service accounts (#930)

### DIFF
--- a/thanos/README.md
+++ b/thanos/README.md
@@ -60,7 +60,7 @@ type: GCS
 ### Example S3 configuration for `object-store.yaml`
 This is an example configuration using thanos with S3. Check endpoints here: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
-```   
+```
 type: S3
 config:
   bucket: ""
@@ -179,20 +179,21 @@ These setting applicable to nearly all components.
 ## Store
 
 These values are just samples, for more fine-tuning please check the values.yaml.
- 
+
 |Name|Description| Default Value|
 |----|-----------|--------------|
 | store.enabled | Enable component | true |
 | store.replicaCount | Pod replica count | 1 |
 | store.logLevel | Log level | info |
-| store.indexCacheSize | Maximum size of items held in the index cache. | 250MB | 
+| store.indexCacheSize | Maximum size of items held in the index cache. | 250MB |
 | store.chunkPoolSize | Maximum size of concurrently allocatable bytes for chunks. | 2GB |
 | store.grpcSeriesSampleLimit | Maximum amount of samples returned via a single series call. 0 means no limit. NOTE: for efficiency we take 120 as the number of samples in chunk (it cannot be bigger than that), so the actual number of samples might be lower, even though the maximum could be hit. | 0 |
 | store.grpcSeriesMaxConcurrency | Maximum number of concurrent Series calls. | 20 |
 | store.syncBlockDuration |Repeat interval for syncing the blocks between local and remote view. | 3m |
 | store.blockSyncConcurrency | Number of goroutines to use when syncing blocks from object storage. | 20 |
 | store.extraEnv | Add extra environment variables | [] |
-| store.extraArgs |Add extra arguments | [] |
+| store.extraArgs | Add extra arguments | [] |
+| store.serviceAccount | Name of the Kubernetes service account to use | "" |
 
 
 ## Query
@@ -212,6 +213,7 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | query.stores | Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. | [] |
 | query.extraEnv | Add extra environment variables | [] |
 | query.extraArgs |Add extra arguments | [] |
+| query.serviceAccount | Name of the Kubernetes service account to use | "" |
 
 
 ## Compact
@@ -221,6 +223,7 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | compact.enabled | Enable component | true |
 | compact.replicaCount | Pod replica count | 1 |
 | compact.logLevel | Log level | info |
+| compact.serviceAccount | Name of the Kubernetes service account to use | "" |
 |consistencyDelay | Minimum age of fresh (non-compacted) blocks before they are being processed. Malformed blocks older than the maximum of consistency-delay and 30m0s will be removed.| 30m |
 | retentionResolutionRaw | How long to retain raw samples in bucket. 0d - disables this retention | 30d |
 | retentionResolution5m | How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention | 120d |
@@ -238,6 +241,7 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | bucket.timeout | Timeout to download metadata from remote storage | 5m |
 | bucket.label | Prometheus label to use as timeline title | "" |
 | bucket.http.port | Listening port for bucket web | 8080 |
+| bucket.serviceAccount | Name of the Kubernetes service account to use | "" |
 
 ## Sidecar
 

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -78,3 +78,6 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}
+      {{- with  .Values.bucket.serviceAccount }}
+      serviceAccountName: "{{ . }}"
+      {{- end }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -87,4 +87,7 @@ spec:
       {{- with .Values.compact.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with  .Values.compact.serviceAccount }}
+      serviceAccountName: "{{ . }}"
+      {{- end }}
 {{- end }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -108,4 +108,7 @@ spec:
       {{- with .Values.compact.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with  .Values.query.serviceAccount }}
+      serviceAccountName: "{{ . }}"
+      {{- end }}
 {{ end }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -37,7 +37,7 @@ spec:
               serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
               servicePort: {{ $.Values.query.http.port }}
   {{- end }}
-{{- end -}}
+{{- end }}
 
 ---
 
@@ -80,4 +80,4 @@ spec:
               serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
               servicePort: {{ $.Values.query.http.port }}
   {{- end }}
-{{- end -}}
+{{- end }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -109,4 +109,7 @@ spec:
       {{- with .Values.compact.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with  .Values.store.serviceAccount }}
+      serviceAccountName: "{{ . }}"
+      {{- end }}
 {{- end }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -37,7 +37,7 @@ spec:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
             servicePort: {{ $.Values.store.http.port }}
   {{- end }}
-  {{- end -}}
+{{- end }}
 
 ---
 
@@ -80,4 +80,4 @@ spec:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
             servicePort: {{ $.Values.store.http.port }}
   {{- end }}
-  {{- end -}}
+{{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -127,6 +127,7 @@ store:
   # Pod affinity
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
   affinity: {}
+  serviceAccount: ""
 
 query:
   enabled: true
@@ -195,6 +196,7 @@ query:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+  serviceAccount: ""
 
   # The http endpoint to communicate with other components
   http:
@@ -331,6 +333,7 @@ compact:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:
       enabled: false
+  serviceAccount: ""
 
   # Optional securityContext
   securityContext: {}
@@ -442,6 +445,7 @@ bucket:
   # Pod affinity
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
   affinity: {}
+  serviceAccount: ""
 
 sidecar:
   # NOTE: This is only the service references for the sidecar


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #930
| License         | Apache 2.0


### What's in this PR?
New helm overrides for settings a service account and README parameters.

### Additional context
Tested on a GKE 1.13.7 cluster with Helm 2.11.0

### Checklist
- [X] Related Helm chart(s) updated (if needed)
