### PR TITLE
s3-output helm configurables

### DIFF
--- a/s3-output/templates/CustomResource.yaml
+++ b/s3-output/templates/CustomResource.yaml
@@ -54,3 +54,7 @@ spec:
           value: "{{ .Values.region }}"
         - name: path
           value: "{{ .Values.path }}"
+        - name: bufferTimeKey
+          value: "{{ .Values.bufferTimeKey }}"
+        - name: bufferTimeWait
+          value: "{{ .Values.bufferTimeWait }}"

--- a/s3-output/templates/CustomResource.yaml
+++ b/s3-output/templates/CustomResource.yaml
@@ -52,3 +52,5 @@ spec:
           value: "{{ .Values.bucketName }}"
         - name: s3_region
           value: "{{ .Values.region }}"
+        - name: path
+          value: "{{ .Values.path }}"

--- a/s3-output/templates/CustomResource.yaml
+++ b/s3-output/templates/CustomResource.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   input:
     label:
-      app: "*"
+      app: "{{ .Values.appPattern }}"
       app.kubernetes.io/name: {{ include "s3-output.name" . }}
       helm.sh/chart: {{ include "s3-output.chart" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}

--- a/s3-output/values.yaml
+++ b/s3-output/values.yaml
@@ -7,6 +7,9 @@ bucketName: ""
 # S3 bucket region
 region: "us-west-1"
 
+# path to log under. must have trailing slash
+path: "logs/${tag}/%Y/%m/%d/"
+
 awsCredentialsAccess:
   enabled: false
   secret:

--- a/s3-output/values.yaml
+++ b/s3-output/values.yaml
@@ -10,6 +10,12 @@ region: "us-west-1"
 # path to log under. must have trailing slash
 path: "logs/${tag}/%Y/%m/%d/"
 
+# slice of time to log per chunk
+bufferTimeKey: 3600
+
+# time to wait before flushing buffer
+bufferTimeWait: 10m
+
 awsCredentialsAccess:
   enabled: false
   secret:

--- a/s3-output/values.yaml
+++ b/s3-output/values.yaml
@@ -16,6 +16,9 @@ bufferTimeKey: 3600
 # time to wait before flushing buffer
 bufferTimeWait: 10m
 
+# app to target
+appPattern: "*"
+
 awsCredentialsAccess:
   enabled: false
   secret:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    |yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds a few different configurables for the s3-output helm chart, in 3 different commits
1. `path` argument to CRD (implemented in banzaicloud/logging-operator#131)
2. buffer-related configurables
3. `app` label, to specify which applications get logs uploaded to s3

In terms of why certain defaults were chosen for these values, I pulled all of these from the defaults that the logging operator uses.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Generically, the helm chart does not expose a lot of the flexibility of the s3-output plugin of the logging operator. These commits should bring us closer to exposing the bulk of the functionality of the operator to helm users.

### Notes

* There doesn't seem to be documentation other than comments for the helm chart. I've left comments for all of the new configuration options.
* This PR is for 3 different commits. They're all solving the same general problem of exposing more functionality through helm. I'm happy to squash the commits or separate them into separate PRs if y'all want.
