### PR TITLE
Fix labeling

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.2
+version: 0.3.3
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: bucket
-  {{ with .Values.bucket.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end -}}
+{{ with .Values.bucket.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end -}}
   {{- with .Values.bucket.deploymentAnnotations }}
 annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: bucket
-        {{ with  .Values.bucket.labels }}{{ toYaml . | indent 8 }}{{ end }}
+{{ with  .Values.bucket.labels }}{{ toYaml . | indent 8 }}{{ end }}
       {{- with  .Values.bucket.annotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/bucket-service.yaml
+++ b/thanos/templates/bucket-service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: bucket
+{{ with .Values.bucket.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   ports:
     - port: {{ .Values.bucket.http.port }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: compact
-  {{ with  .Values.compact.labels }}{{ toYaml . | indent 8 }}{{ end }}
+{{ with  .Values.compact.labels }}{{ toYaml . | indent 8 }}{{ end }}
       {{- with  .Values.compact.annotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/compact-service.yaml
+++ b/thanos/templates/compact-service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: compact
+{{ with .Values.compact.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   ports:
   - port: {{ .Values.compact.http.port }}

--- a/thanos/templates/compact-servicemonitor.yaml
+++ b/thanos/templates/compact-servicemonitor.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: compact
+{{ with .Values.compact.metrics.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   jobLabel: thanos-compact
   selector:

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: query
-  {{ with  .Values.query.labels }}{{ toYaml . | indent 8 }}{{ end }}
+{{ with  .Values.query.labels }}{{ toYaml . | indent 8 }}{{ end }}
       {{- with  .Values.query.annotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/query-service.yaml
+++ b/thanos/templates/query-service.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query
+{{ with .Values.query.grpc.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -42,6 +43,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query
+{{ with .Values.query.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: {{ .Values.query.http.service.type }}
   {{- if .Values.query.http.service.externalTrafficPolicy }}

--- a/thanos/templates/query-servicemonitor.yaml
+++ b/thanos/templates/query-servicemonitor.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query
+{{ with .Values.query.metrics.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   jobLabel: thanos-query
   selector:

--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: sidecar
+{{ with .Values.sidecar.grpc.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -40,6 +41,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: sidecar
+{{ with .Values.store.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: {{ .Values.sidecar.http.service.type }}
   {{- if .Values.sidecar.http.service.externalTrafficPolicy }}

--- a/thanos/templates/sidecar-servicemonitor.yaml
+++ b/thanos/templates/sidecar-servicemonitor.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: sidecar
+{{ with .Values.sidecar.metrics.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   jobLabel: thanos-sidecar
   selector:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
-  {{ with .Values.store.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.store.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end }}
   {{- with .Values.store.deploymentAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -23,7 +23,8 @@ spec:
       app.kubernetes.io/component: store
   template:
     metadata:
-      labels: {{ with  .Values.store.labels }}{{ toYaml . | nindent 8 }}{{ end }}
+      labels: 
+{{ with .Values.store.labels }}{{ toYaml . | indent 8 }}{{ end }}
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: store

--- a/thanos/templates/store-service.yaml
+++ b/thanos/templates/store-service.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
+{{ with .Values.store.grpc.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -42,6 +43,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
+{{ with .Values.store.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: {{ .Values.store.http.service.type }}
   {{- if .Values.store.http.service.externalTrafficPolicy }}

--- a/thanos/templates/store-servicemonitor.yaml
+++ b/thanos/templates/store-servicemonitor.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
+{{ with .Values.store.metrics.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   jobLabel: thanos-store
   selector:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -55,6 +55,8 @@ store:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:
       enabled: false
+      # Labels for prometheus-operator to find servicemonitor
+      labels: {}
   # The grpc endpoint to communicate with other components
   grpc:
     # grpc listen port number
@@ -63,6 +65,8 @@ store:
     service:
       # Annotations to query grpc service
       annotations: {}
+      # Labels to query grpc service
+      labels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -87,6 +91,8 @@ store:
       type: ClusterIP
       # Annotations to query http service
       annotations: {}
+      # Labels to query http service
+      labels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -182,6 +188,8 @@ query:
     service:
       # Annotations to query grpc service
       annotations: {}
+      # labels to query grpc service
+      labels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -207,6 +215,8 @@ query:
       type: ClusterIP
       # Annotations to query http service
       annotations: {}
+      # Labels to query http service
+      labels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -240,6 +250,8 @@ query:
   #  extraAnnotation: extraAnnotationValue
   #
   # Enable metrics collecting for compat service
+
+
   metrics:
     # This is the Prometheus annotation type scraping configuration
     annotations:
@@ -247,6 +259,8 @@ query:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:
       enabled: false
+      # Labels for prometheus-operator to find servicemonitor
+      labels: {}
 
   # Optional securityContext
   securityContext: {}
@@ -295,6 +309,8 @@ compact:
   # Compact service listening http port
   http:
     port: 10902
+    service:
+      labels: {}
   # Add extra environment variables to compact
   extraEnv:
   # - name: ENV
@@ -333,6 +349,8 @@ compact:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:
       enabled: false
+      # Labels for prometheus-operator to find servicemonitor
+      labels: {}
   serviceAccount: ""
 
   # Optional securityContext
@@ -381,6 +399,8 @@ bucket:
       type: ClusterIP
       # Annotations to query http service
       annotations: {}
+      # Labels to query http service
+      labels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -455,6 +475,8 @@ sidecar:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:
       enabled: false
+      # Labels for prometheus-operator to find servicemonitor
+      labels: {}
   # The grpc endpoint to communicate with other components
   grpc:
     # grpc listen port number
@@ -463,6 +485,8 @@ sidecar:
     service:
       # Annotations to query grpc service
       annotations: {}
+      # Labels to query grpc service
+      labels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -487,6 +511,8 @@ sidecar:
       type: ClusterIP
       # Annotations to query http service
       annotations: {}
+      # Labels to query http service
+      labels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        yes
| New feature?    yes
| API breaks?     Shouldn't be
| Deprecations?   | no
| Related tickets | no


### What's in this PR?
Indentation for deployment labelings were off.
Added the option to add labeling to services and service monitors.


### Why?
Deployment label bug breaks the whole deployment if labels were set in values.yaml

Prometheus operators finds service monitors by matching specific labels. Adding this functionality would allow flexibility for both sides of stable/prometheus-operator and banzaicloud-stable/thanos charts.

Same idea for service monitors finding services.

