### PR TITLE
Update Cadence charts to allow specifying nodeport

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.7.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -229,6 +229,7 @@ Global options overridable per service are marked with an asterisk.
 | `server.[service].nodeSelector`                   | `[service]` Node labels for pod assignment            | `{}`                  |
 | `server.[service].tolerations`                    | `[service]` Toleration labels for pod assignment      | `[]`                  |
 | `server.[service].affinity`                       | `[service]` Affinity settings for pod assignment      | `{}`                  |
+| `server.frontend.service.nodePort`                | frontend service nodePort, if service type is NodePort| ``                    |
 | `web.enabled`                                     | Enable WebUI service                                  | `true`                |
 | `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
@@ -236,6 +237,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |
 | `web.service.port`                                | WebUI service port                                    | `80`                  |
+| `web.service.nodePort`                            | WebUI service nodePort, if service type is NodePort   | ``                    |
 | `web.ingress.enabled`                             | Enable WebUI Ingress                                  | `false`               |
 | `web.ingress.annotations`                         | WebUI Ingress annotations                             | `{}`                  |
 | `web.ingress.hosts`                               | WebUI Ingress hosts                                   | `/`                   |

--- a/cadence/templates/server-service.yaml
+++ b/cadence/templates/server-service.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: rpc
       protocol: TCP
       name: rpc
+      {{- if hasKey .Values.server.frontend.service "nodePort" }}
+      nodePort: {{ .Values.server.frontend.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/cadence/templates/web-service.yaml
+++ b/cadence/templates/web-service.yaml
@@ -25,6 +25,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if hasKey .Values.web.service "nodePort" }}
+      nodePort: {{ .Values.web.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "cadence.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR adds the support for specifying `nodePort` for cadence frontend and web service in the helm chart. Bumping the chart's minor version.

### Why?
This is useful in case the type for these services is chosen as NodePort to expose it outside the cluster and having NodePort fixed allows us to set up our own load balancing solution.
