### PR TITLE
thanos: fix store component deployment variables

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.6.1
+appVersion: 0.6.2
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -98,16 +98,16 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.store.certSecretName }}
       {{- end }}
-      {{- with .Values.compact.securityContext }}
+      {{- with .Values.store.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.nodeSelector }}
+      {{- with .Values.store.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.affinity }}
+      {{- with .Values.store.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.tolerations }}
+      {{- with .Values.store.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with  .Values.store.serviceAccount }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
`store-deployment.yaml` was with incorrect values referenced (it was from `compact` component)
