### PR TITLE
thanos: autoscaling and poddisruption resources for essential components

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.6.1
+appVersion: 0.6.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.3
+version: 0.3.5
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -212,7 +212,15 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | query.sidecarDNSDiscovery | Enable DNS discovery for sidecars (this is for the chart built-in sidecar service) | true |
 | query.stores | Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. | [] |
 | query.extraEnv | Add extra environment variables | [] |
-| query.extraArgs |Add extra arguments | [] |
+| query.extraArgs | Add extra arguments | [] |
+| query.podDisruptionBudget.enabled | Enabled and config podDisruptionBudget resource for this component | false |
+| query.podDisruptionBudget.minAvailable | Minimum number of available query pods for PodDisruptionBudget | 1 |
+| query.podDisruptionBudget.maxUnavailable | Maximum number of unavailable query pods for PodDisruptionBudget | [] |
+| query.autoscaling.enabled | Enabled and config horizontalPodAutoscaling resource for this component | false |
+| query.autoscaling.minReplicas |	If autoscaling enabled, this field sets minimum replica count |	2 |
+| query.autoscaling.maxReplicas |	If autoscaling enabled, this field sets maximum replica count |	3 |
+| query.autoscaling.targetCPUUtilizationPercentage | 	Target CPU utilization percentage to scale | 50 |
+| query.autoscaling.targetMemoryUtilizationPercentage |	Target memory utilization percentage to scale 50 |
 | query.serviceAccount | Name of the Kubernetes service account to use | "" |
 
 
@@ -236,12 +244,16 @@ These values are just samples, for more fine-tuning please check the values.yaml
 |Name|Description| Default Value|
 |----|-----------|--------------|
 | bucket.enabled | Enable component | true |
+| bucket.replicaCount | Pod replica count | 1 |
 | bucket.logLevel | Log level | info |
 | bucket.refresh | Refresh interval to download metadata from remote storage | 30m |
 | bucket.timeout | Timeout to download metadata from remote storage | 5m |
 | bucket.label | Prometheus label to use as timeline title | "" |
 | bucket.http.port | Listening port for bucket web | 8080 |
 | bucket.serviceAccount | Name of the Kubernetes service account to use | "" |
+| bucket.podDisruptionBudget.enabled | Enabled and config podDisruptionBudget resource for this component | false |
+| bucket.podDisruptionBudget.minAvailable | Minimum number of available query pods for PodDisruptionBudget | 1 |
+| bucket.podDisruptionBudget.maxUnavailable | Maximum number of unavailable query pods for PodDisruptionBudget | [] |
 
 ## Sidecar
 

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.bucket.replicas | default 1 }}
+  replicas: {{ .Values.bucket.replicaCount | default 1 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/bucket-poddisruptionbudget.yaml
+++ b/thanos/templates/bucket-poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.bucket.enabled .Values.bucket.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "thanos.componentname" (list $ "bucket") }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: bucket
+{{ with .Values.bucket.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end }}
+spec:
+  {{- if .Values.bucket.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.bucket.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.bucket.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.bucket.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
+      app.kubernetes.io/component: bucket
+{{- end }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -15,7 +15,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if not .Values.query.autoscaling.enabled  }}
   replicas: {{ .Values.query.replicaCount | default 1 }}
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/query-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-horizontalpodautoscaler.yaml
@@ -19,16 +19,16 @@ spec:
   minReplicas: {{ .Values.query.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.query.autoscaling.maxReplicas }}
   metrics:
-{{- with .Values.query.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
-{{- end }}
 {{- with .Values.query.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.query.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         targetAverageUtilization: {{ . }}
 {{- end }}
 {{- end }}

--- a/thanos/templates/query-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-horizontalpodautoscaler.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.query.enabled }}
+{{- if .Values.query.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "thanos.componentname" (list $ "query") }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: query
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "thanos.componentname" (list $ "query") }}
+  minReplicas: {{ .Values.query.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.query.autoscaling.maxReplicas }}
+  metrics:
+{{- with .Values.query.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.query.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/thanos/templates/query-poddisruptionbudget.yaml
+++ b/thanos/templates/query-poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.query.enabled .Values.query.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "thanos.componentname" (list $ "query") }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: query
+{{ with .Values.query.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end }}
+spec:
+  {{- if .Values.query.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.query.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.query.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.query.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
+      app.kubernetes.io/component: query
+{{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -180,6 +180,14 @@ query:
   #
   # Number of replicas running from query component
   replicaCount: 1
+
+  # Enable podDisruptionBudget for query component
+  podDisruptionBudget:
+    enabled: false
+      # minAvailable and maxUnavailable can't be used simultaneous. Choose one.
+    minAvailable: 1
+    #  maxUnavailable: 50%
+
   # The grpc endpoint to communicate with other components
   grpc:
     # grpc listen port number
@@ -438,6 +446,13 @@ bucket:
   #
   # Add extra annotations to bucket deployment
   deploymentAnnotations: {}
+
+  # Enable podDisruptionBudget for query component
+  podDisruptionBudget:
+    enabled: false
+      # minAvailable and maxUnavailable can't be used simultaneous. Choose one.
+    minAvailable: 1
+    #  maxUnavailable: 50%
 
   # Optional securityContext
   securityContext: {}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -180,7 +180,13 @@ query:
   #
   # Number of replicas running from query component
   replicaCount: 1
-
+  # Enable HPA for query component
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
   # Enable podDisruptionBudget for query component
   podDisruptionBudget:
     enabled: false

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -390,6 +390,8 @@ compact:
 
 bucket:
   enabled: true
+  # Number of replicas running from bucket component
+  replicaCount: 1
   # Log filtering level.
   logLevel: info
   # Refresh interval to download metadata from remote storage


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Added possibility to use `podDisruptionBudget` resources in thanos `query` and `bucket`component and `horizontalPodAutoscaling` only in `query`.


### Why?
`thanos-query` component in some environments need an HA to being queried by Grafana or any other monitoring service. In some situations (like preemptible nodes) it's desirable to have a basic resilience config to not disrupt alerting.

For `thanos-bucket` is just for the sake of HA access.
The other components (compact and store) maybe are made to be ready to fail, so I thought that it wasn't necessary.