### PR TITLE
Thanos - Fix incorrect query deployment variable names

### DIFF
--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -96,16 +96,16 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.query.certSecretName }}
       {{- end }}
-      {{- with .Values.compact.securityContext }}
+      {{- with .Values.query.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.nodeSelector }}
+      {{- with .Values.query.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.affinity }}
+      {{- with .Values.query.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.tolerations }}
+      {{- with .Values.query.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with  .Values.query.serviceAccount }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
thanos query deployment values for the following have been updated to reference query values rather than compact :
 
* securityContext
* nodeSelector
* affinity
* tolerations



### Why?
values would be set according to the **compact**  component helm values instead of the **query** component  leading to resource taint

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Related Helm chart(s) updated (if needed)
