### PR TITLE
thanos: sidecar http svc with wrong selectors

### DIFF
--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -53,8 +53,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "thanos.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: sidecar
-
+    app: prometheus
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Sidecar's http service was with wrong selector and wasn't binded in the sidecar like gRPC's because wrong labels.

### Why?
When no HTTP service is set, service monitor can't scrape **/metrics** for prometheus because the service never reaches the backend pods.