### PR TITLE
thanos: unnecessary secret resource when deploying only sidecar services

### DIFF
--- a/thanos/templates/secret.yaml
+++ b/thanos/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.bucket.enabled .Values.store.enabled .Values.compact.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- else }}
   object-store.yaml: {{ .Values.objstoreFile  | b64enc }}
   {{- end }}
+{{- end }}

--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -53,8 +53,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "thanos.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: sidecar
-
+    app: prometheus
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes ?
| New feature?    | no
| API breaks?     | no|
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Conditional `secret` manifest  who only is deployed in case `compact`, `store` or `bucket` are too. They are the only components that need this resource.

### Why?
Use cases where you want/need to distribute your stack in different clusters. In our case we have a central `query` and `store` and `sidecars` spread trough 5 other clusters. These sidecars are only services (because the actual container is deployed by `prometheus-operator` or any other form, as this chart doesn't support it) and don't need the secret to me functional. 