### PR TITLE
Capability to define include rule in namespaceSelector

### DIFF
--- a/anchore-policy-validator/Chart.yaml
+++ b/anchore-policy-validator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.4.3
-appVersion: 0.3.4
+version: 0.4.4
+appVersion: 0.3.6
 keywords:
  - analysis
  - "anchore-policy-validator"

--- a/anchore-policy-validator/README.md
+++ b/anchore-policy-validator/README.md
@@ -40,7 +40,7 @@ The following tables lists configurable parameters of the anchore-policy-validat
 |apiService.group                     |group of registered api service              |admission.anchore.io                      |
 |apiService.version                   |version of registered api service            |v1beta1                                   |
 |image.repository                     |admission-server image repo                  |banzaicloud/anchore-image-validator       |
-|image.tag                            |admission-server image tag                   |0.3.0                                     |
+|image.tag                            |admission-server image tag                   |0.3.6                                     |
 |image.pullPolicy                     |admission-server image pull policy           |IfNotPresent                              |
 |service.name                         |validation sevice name                       |anchoreimagecheck                         |
 |service.type                         |validation service type                      |ClusterIP                                 |
@@ -51,3 +51,4 @@ The following tables lists configurable parameters of the anchore-policy-validat
 |externalAnchore.anchorePass          |external anchore-engine password             |""                                        |
 |rbac.enabled                         |enable RBAC                                  |true                                      |
 |rbac.psp.enabled                     |add PSP resources if enabled                 |false                                     |
+|webhookSelector                      |webHookConfig namespaceSelector behaviour    |"" (exclude)                              |

--- a/anchore-policy-validator/README.md
+++ b/anchore-policy-validator/README.md
@@ -51,4 +51,4 @@ The following tables lists configurable parameters of the anchore-policy-validat
 |externalAnchore.anchorePass          |external anchore-engine password             |""                                        |
 |rbac.enabled                         |enable RBAC                                  |true                                      |
 |rbac.psp.enabled                     |add PSP resources if enabled                 |false                                     |
-|webhookSelector                      |webHookConfig namespaceSelector behaviour    |"" (exclude)                              |
+|namespaceSelector                    |webHookConfig namespaceSelector behaviour    |"" (exclude)                              |

--- a/anchore-policy-validator/templates/validator-deployment.yaml
+++ b/anchore-policy-validator/templates/validator-deployment.yaml
@@ -52,8 +52,8 @@ spec:
             value: {{ .Values.externalAnchore.anchorePass }}
           - name: ANCHORE_ENGINE_URL
             value: {{ .Values.externalAnchore.anchoreHost }}
-          - name: WEBHOOK_SELECTOR
-            value: {{ default "exclude" .Values.webhookSelector }}
+          - name: NAMESPACE_SELECTOR
+            value: {{ default "exclude" .Values.namespaceSelector }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/anchore-policy-validator/templates/validator-deployment.yaml
+++ b/anchore-policy-validator/templates/validator-deployment.yaml
@@ -52,6 +52,8 @@ spec:
             value: {{ .Values.externalAnchore.anchorePass }}
           - name: ANCHORE_ENGINE_URL
             value: {{ .Values.externalAnchore.anchoreHost }}
+          - name: WEBHOOK_SELECTOR
+            value: {{ default "exclude" .Values.webhookSelector }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -18,7 +18,7 @@ externalAnchore:
   anchorePass: ""
 resources: {}
 
-webhookSelector: ""
+namespaceSelector: ""
 
 ## Node selector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/anchore-policy-validator/values.yaml
+++ b/anchore-policy-validator/values.yaml
@@ -5,7 +5,7 @@ apiService:
   version: v1beta1
 image:
   repository: banzaicloud/anchore-image-validator
-  tag: 0.3.4
+  tag: 0.3.6
   pullPolicy: IfNotPresent
 service:
   name: anchoreimagecheck
@@ -17,6 +17,8 @@ externalAnchore:
   anchoreUser: ""
   anchorePass: ""
 resources: {}
+
+webhookSelector: ""
 
 ## Node selector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related PR | merge after: https://github.com/banzaicloud/anchore-image-validator/pull/39
| License         | Apache 2.0

### What's in this PR?
The PR implements include/exclude switch in case of validatingWebhookConfig. The default image scan behavior is excluding namespaces.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
