### PR TITLE
Support for Thanos v0.8.0 ; Adding query readiness probe and store readiness + health probes

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.5
+version: 0.3.6
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -136,8 +136,8 @@ This section describes the values available
 ## General
 |Name|Description| Default Value|
 |----|-----------|--------------|
-| image.repository | Thanos image repository and name | improbable/thanos |
-| image.tag | Thanos image tag | v0.6.0 |
+| image.repository | Thanos image repository and name | 'quay.io/thanos/thanos'   **For Thanos version 0.6.0 or older change this to 'improbable/thanos'** |
+| image.tag | Thanos image tag | v0.8.0 |
 | image.pullPolicy | Image Kubernetes pull policy | IfNotPresent |
 | objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with objstoreFile. | {} |
 | objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with objstore. | "" |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -137,7 +137,7 @@ This section describes the values available
 |Name|Description| Default Value|
 |----|-----------|--------------|
 | image.repository | Thanos image repository and name | 'quay.io/thanos/thanos'   **For Thanos version 0.6.0 or older change this to 'improbable/thanos'** |
-| image.tag | Thanos image tag | v0.8.0 |
+| image.tag | Thanos image tag | v0.8.1 |
 | image.pullPolicy | Image Kubernetes pull policy | IfNotPresent |
 | objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with objstoreFile. | {} |
 | objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with objstore. | "" |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -194,6 +194,8 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | store.extraEnv | Add extra environment variables | [] |
 | store.extraArgs | Add extra arguments | [] |
 | store.serviceAccount | Name of the Kubernetes service account to use | "" |
+| store.livenessProbe  | Set up liveness probe for store available for Thanos v0.8.0+) |  {} |
+| store.readinessProbe  | Set up readinessProbe for store (available for Thanos v0.8.0+) | {}  |
 
 
 ## Query

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -91,6 +91,10 @@ spec:
           httpGet:
             path: /-/healthy
             port: http
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: http
       {{- if .Values.query.certSecretName }}
       volumes:
       - name: {{ .Values.query.certSecretName }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -84,14 +84,14 @@ spec:
           name: {{ .Values.store.certSecretName }}
           readOnly: true
         {{- end }}
+        {{- if .Values.store.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: http
+        {{ toYaml .Values.store.livenessProbe | nindent 8 }}
+        {{- end }}
+        {{- if .Values.store.readinessProbe }}
         readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: http
+        {{ toYaml .Values.store.readinessProbe | nindent 8 }}
+        {{- end }}
         resources:
           {{ toYaml .Values.store.resources | nindent 10 }}
       volumes:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/component: store
   template:
     metadata:
-      labels: 
+      labels:
 {{ with .Values.store.labels }}{{ toYaml . | indent 8 }}{{ end }}
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -84,6 +84,14 @@ spec:
           name: {{ .Values.store.certSecretName }}
           readOnly: true
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: http
         resources:
           {{ toYaml .Values.store.resources | nindent 10 }}
       volumes:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -134,6 +134,10 @@ store:
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
   affinity: {}
   serviceAccount: ""
+  # set up store readinessProbe & livenessProbe
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe: {}
+  readinessProbe: {}
 
 query:
   enabled: true

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: improbable/thanos
-  tag: v0.6.0
+  repository: quay.io/thanos/thanos
+  tag: v0.8.0
   pullPolicy: IfNotPresent
 
 store:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/thanos/thanos
-  tag: v0.8.0
+  tag: v0.8.1
   pullPolicy: IfNotPresent
 
 store:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Thanos released version 0.8.0 with bug fixes and readiness probes features. 
https://thanos.io/changelog/#v0-8-0-https-github-com-thanos-io-thanos-releases-tag-v0-8-0-2019-10-10

I Just changed the default version to v0.8.1 per the bug fixes. Thank to @tarokkk for the comment.

I also changed the default image repository as the Thanos.io is using Quay since v0.7.0 (https://thanos.io/changelog/#v0-7-0-https-github-com-thanos-io-thanos-releases-tag-v0-7-0-2019-09-02) 


### Why?
Thanos new features - probes and bug fixes

### Additional context
N/A


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
