### PR TITLE
thanos: Add file service discovery options to Query

### DIFF
--- a/thanos/README.md
+++ b/thanos/README.md
@@ -211,6 +211,8 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | query.storeDNSDiscovery | Enable DNS discovery for stores | true |
 | query.sidecarDNSDiscovery | Enable DNS discovery for sidecars (this is for the chart built-in sidecar service) | true |
 | query.stores | Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. | [] |
+| query.serviceDiscoveryFiles | Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable). | [] |
+| query.serviceDiscoveryInterval | Refresh interval to re-read file SD files. It is used as a resync fallback. | 5m |
 | query.extraEnv | Add extra environment variables | [] |
 | query.extraArgs | Add extra arguments | [] |
 | query.podDisruptionBudget.enabled | Enabled and config podDisruptionBudget resource for this component | false |

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -71,6 +71,12 @@ spec:
         {{- range .Values.query.stores }}
         - "--store={{ . }}"
         {{- end }}
+        {{- range .Values.query.serviceDiscoveryFiles }}
+        - "--store.sd-files={{ . }}"
+        {{- end }}
+        {{- if .Values.query.serviceDiscoveryInterval }}
+        - "--store.sd-interval={{ .Values.query.serviceDiscoveryInterval }}"
+        {{- end }}
         {{- if .Values.query.extraArgs }}
         {{ toYaml .Values.query.extraArgs | nindent 8 }}
         {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -167,6 +167,10 @@ query:
   stores: []
   #  - "dnssrv+_grpc._tcp.<service>.<namespace>.svc.cluster.local"
   #
+  # Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable).
+  serviceDiscoveryFiles: []
+  # Refresh interval to re-read file SD files. It is used as a resync fallback.
+  serviceDiscoveryInterval: 5m
   # Log filtering level.
   logLevel: info
   # Add extra environment variables to compact


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?   | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
We should expose the File Service Discovery functionality that Thanos provides for Query. This PR adds these options.


### Why?
File Service Discovery is a useful option for service discovery already offered in Thanos should be leveraged in this chart.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

