### PR TITLE
[thanos] Add persistentVolumeClaim for compact component

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.6
+version: 0.3.7
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -262,6 +262,8 @@ timePartioning:
 | retentionResolution1h | How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention | 1y |
 | compactConcurrency | Number of goroutines to use when syncing block metadata from object storage. | 20 |
 | blockSyncConcurrency | Number of goroutines to use when compacting groups. | 1 |
+| dataVolume.backend | Data volume for the compactor to store temporary data defaults to emptyDir. | {} |
+| persistentVolumeClaim | Create the specified persistentVolumeClaim in case persistentVolumeClaim is used for the dataVolume.backend above and needs to be created. | {} |
 
 ## Bucket
 

--- a/thanos/templates/compact-persistentvolumeclaim.yaml
+++ b/thanos/templates/compact-persistentvolumeclaim.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.compact.persistentVolumeClaim }}
+{{- $pvc := .Values.compact.persistentVolumeClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $pvc.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: compact
+{{ with .Values.compact.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end -}}
+  {{- with .Values.compact.deploymentAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $pvc.spec | nindent 2 }}
+{{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -352,6 +352,19 @@ compact:
     backend: {}
     #  persistentVolumeClaim:
     #    claimName: compact-data-volume
+  # Create the specified persistentVolumeClaim in case persistentVolumeClaim is
+  # used for the dataVolume.backend above and needs to be created.
+  persistentVolumeClaim: {}
+  #  name: compact-data-volume
+  #  spec:
+  #    storageClassName: ""
+  #    accessModes: ["ReadWriteOnce"]
+  #    resources:
+  #      requests:
+  #        storage: 100Gi
+  #    selector: {}
+  #    volumeName: ""
+  #    volumeMode: ""
   # Extra labels for compact pod template
   labels: {}
   #  cluster: example


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add the ability to create persistentVolumeClaim for Thanos compact component's dataVolume backend. By default, the persistentVolumeClaim wouldn't be created (same behavior as before). Just in case people want to create and use persistentVolumeClaim in the same chart, this PR would allow it.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Have locally tested with helm lint and install

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
