### PR TITLE
Allow disable common cluster role bindings wich might be already created

### DIFF
--- a/kube-metrics-adapter/Chart.yaml
+++ b/kube-metrics-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-metrics-adapter
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.0.2
 description: A Helm chart for kube-metrics-adapter
 home: https://github.com/zalando-incubator/kube-metrics-adapter

--- a/kube-metrics-adapter/README.md
+++ b/kube-metrics-adapter/README.md
@@ -45,7 +45,8 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |                                                                                                        
+| `rbac.hpa_bindings_enabled`     | Create cluter role bindings for HPA (might alreas by created by another app)    | `true`                                      |
+| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        | 
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.internalPort`          | Service internal port                                                           | `6443`                                      |

--- a/kube-metrics-adapter/templates/rbac.yaml
+++ b/kube-metrics-adapter/templates/rbac.yaml
@@ -95,6 +95,7 @@ rules:
   - list
   - watch
 ---
+{{ if .Values.rbac.hpa_bindings_enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -131,6 +132,7 @@ subjects:
   name: horizontal-pod-autoscaler
   namespace: kube-system
 ---
+{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/kube-metrics-adapter/values.yaml
+++ b/kube-metrics-adapter/values.yaml
@@ -14,6 +14,9 @@ replicas: 1
 rbac:
   # Specifies whether RBAC resources should be created
   enabled: true
+  # Specifies whater to create common cluster role bindings for HPA
+  # (might be already created by another app).
+  hpa_bindings_enabled: true
   psp:
     enabled: false
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?

Update helm chart for kube-metrics-adapter.

### Why?

For exaple Prometheus metrics adapter creates those bindings as well (with identical names), instalation of this helm chart fails because of coliding names.
