### PR TITLE
kube-metrics-adapter: add missing pullSecrets implementations

### DIFF
--- a/kube-metrics-adapter/Chart.yaml
+++ b/kube-metrics-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-metrics-adapter
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.0.2
 description: A Helm chart for kube-metrics-adapter
 home: https://github.com/zalando-incubator/kube-metrics-adapter

--- a/kube-metrics-adapter/README.md
+++ b/kube-metrics-adapter/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `image.repository`              | Image repository                                                                | `banzaicloud/kube-metrics-adapter`          |
 | `image.tag`                     | Image tag                                                                       | `0.1.1`                                     |
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
-| `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
+| `image.pullSecrets`             | Image pull secrets                                                              | `[]`                                        |
 | `logLevel`                      | Log level                                                                       | `4`                                         |
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |

--- a/kube-metrics-adapter/templates/deployment.yaml
+++ b/kube-metrics-adapter/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           mountPath: {{ .Values.sslCertPath }}
           readOnly: true
         {{- end}}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/kube-metrics-adapter/values.yaml
+++ b/kube-metrics-adapter/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: banzaicloud/kube-metrics-adapter
   tag: 0.1.1
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 logLevel: 9
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?

`pullSecrets` is documented in `README.md` but actualy not implemented, this adds the missing implementation.

### Why?

Using this helm chart with docker registry wich requires login.
