### PR TITLE
[thanos] Add autoDownsampling for query component

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.7
+version: 0.3.8
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -226,6 +226,7 @@ timePartioning:
 | query.replicaCount | Pod replica count | 1 |
 | query.logLevel | Log level | info |
 | query.replicaLabel | Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter. | "" |
+| query.autoDownsampling | Enable --query.auto-downsampling option for query. | false |
 | query.webRoutePrefix |Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus. | "" |
 | query.webExternalPrefix |Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path | "" |
 | query.webPrefixHeader | Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path | "" |

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -53,6 +53,9 @@ spec:
         {{- if .Values.query.replicaLabel }}
         - "--query.replica-label={{ .Values.query.replicaLabel }}"
         {{- end }}
+        {{- if .Values.query.autoDownsampling }}
+        - "--query.auto-downsampling"
+        {{- end }}
         {{- if .Values.query.webRoutePrefix }}
         - "--web.route-prefix={{ .Values.query.webRoutePrefix }}"
         {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -149,6 +149,8 @@ query:
   # Label to treat as a replica indicator along which data is deduplicated.
   # Still you will be able to query without deduplication using 'dedup=false' parameter.
   replicaLabel: ""
+  # Enable --query.auto-downsampling option for query.
+  autoDownsampling: false
   # Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path.
   # This option is analogous to --web.route-prefix of Promethus.
   webRoutePrefix: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add query.autoDownsampling config in Thanos chart to allow --query.auto-downsampling option to be added in the query component.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Have locally tested with helm lint and install.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
