### PR TITLE
[Thanos] Compact concurrency default values

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.8
+version: 0.3.9
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -261,8 +261,8 @@ timePartioning:
 | compact.retentionResolutionRaw | How long to retain raw samples in bucket. 0d - disables this retention | 30d |
 | compact.retentionResolution5m | How long to retain samples of resolution 1 (5 minutes) in bucket. 0d - disables this retention | 120d |
 | compact.retentionResolution1h | How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention | 1y |
-| compact.compactConcurrency | Number of goroutines to use when syncing block metadata from object storage. | 20 |
-| compact.blockSyncConcurrency | Number of goroutines to use when compacting groups. | 1 |
+| compact.blockSyncConcurrency | Number of goroutines to use when syncing block metadata from object storage. | 20 |
+| compact.compactConcurrency | Number of goroutines to use when compacting groups. | 1 |
 | compact.dataVolume.backend | Data volume for the compactor to store temporary data defaults to emptyDir. | {} |
 | compact.persistentVolumeClaim | Create the specified persistentVolumeClaim in case persistentVolumeClaim is used for the dataVolume.backend above and needs to be created. | {} |
 

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -332,9 +332,9 @@ compact:
   # How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention
   retentionResolution1h: 1y
   # Number of goroutines to use when syncing block metadata from object storage.
-  compactConcurrency: 20
+  blockSyncConcurrency: 20
   # Number of goroutines to use when compacting groups.
-  blockSyncConcurrency: 1
+  compactConcurrency: 1
   # Log filtering level.
   logLevel: info
   # Compact service listening http port


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
Updates the default values for compact.blockSyncConcurrency and compact.compactConcurrency and their reference

### Why?
The explanation and default values for these parameters are swapped around in the readme and in the default `values.yaml` file.

### Additional context
While the values of a single thread for block sync and 20 thread for block compaction are not technically broken, they differs significantly from the one used in the Thanos Documentation ([Ref. here](https://github.com/thanos-io/thanos/blob/v0.8.1/docs/components/compact.md#flags)) which seems to be used as default for the rest of this chart.

### Checklist
- [x] User guide and development docs updated (if needed)

### To Do
- [ ] Review version bump as this is technically not fully backward compatible (different default)