### PR TITLE
[thanos] Improve query file SD mechanism using configmaps

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.9
+version: 0.3.10
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -234,7 +234,7 @@ timePartioning:
 | query.storeDNSDiscovery | Enable DNS discovery for stores | true |
 | query.sidecarDNSDiscovery | Enable DNS discovery for sidecars (this is for the chart built-in sidecar service) | true |
 | query.stores | Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. | [] |
-| query.serviceDiscoveryFiles | Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable). | [] |
+| query.serviceDiscoveryFileConfigMaps | Names of configmaps that contain addresses of store API servers, used for file service discovery. | [] |
 | query.serviceDiscoveryInterval | Refresh interval to re-read file SD files. It is used as a resync fallback. | 5m |
 | query.extraEnv | Add extra environment variables | [] |
 | query.extraArgs | Add extra arguments | [] |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -234,6 +234,7 @@ timePartioning:
 | query.storeDNSDiscovery | Enable DNS discovery for stores | true |
 | query.sidecarDNSDiscovery | Enable DNS discovery for sidecars (this is for the chart built-in sidecar service) | true |
 | query.stores | Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups. | [] |
+| query.serviceDiscoveryFiles | Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable). | [] |
 | query.serviceDiscoveryFileConfigMaps | Names of configmaps that contain addresses of store API servers, used for file service discovery. | [] |
 | query.serviceDiscoveryInterval | Refresh interval to re-read file SD files. It is used as a resync fallback. | 5m |
 | query.extraEnv | Add extra environment variables | [] |

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -80,6 +80,9 @@ spec:
         {{- range .Values.query.stores }}
         - "--store={{ . }}"
         {{- end }}
+        {{- range .Values.query.serviceDiscoveryFiles }}
+        - "--store.sd-files={{ . }}"
+        {{- end }}
         {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
         - "--store.sd-files=/etc/query/{{ . }}/*.yaml"
         - "--store.sd-files=/etc/query/{{ . }}/*.yml"

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -80,8 +80,10 @@ spec:
         {{- range .Values.query.stores }}
         - "--store={{ . }}"
         {{- end }}
-        {{- range .Values.query.serviceDiscoveryFiles }}
-        - "--store.sd-files={{ . }}"
+        {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
+        - "--store.sd-files=/etc/query/{{ . }}/*.yaml"
+        - "--store.sd-files=/etc/query/{{ . }}/*.yml"
+        - "--store.sd-files=/etc/query/{{ . }}/*.json"
         {{- end }}
         {{- if .Values.query.serviceDiscoveryInterval }}
         - "--store.sd-interval={{ .Values.query.serviceDiscoveryInterval }}"
@@ -96,8 +98,12 @@ spec:
           containerPort: {{ .Values.query.grpc.port }}
         resources:
           {{ toYaml .Values.query.resources | nindent 10 }}
-        {{- if .Values.query.certSecretName }}
         volumeMounts:
+        {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
+        - mountPath: /etc/query/{{ . }}
+          name: {{ . }}
+        {{- end }}
+        {{- if .Values.query.certSecretName }}
         - mountPath: /etc/certs
           name: {{ .Values.query.certSecretName }}
           readOnly: true
@@ -110,8 +116,14 @@ spec:
           httpGet:
             path: /-/ready
             port: http
-      {{- if .Values.query.certSecretName }}
       volumes:
+      {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
+      - name: {{ . }}
+        configMap:
+          defaultMode: 420
+          name: {{ . }}
+      {{- end }}
+      {{- if .Values.query.certSecretName }}
       - name: {{ .Values.query.certSecretName }}
         secret:
           defaultMode: 420

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -180,6 +180,8 @@ query:
   stores: []
   #  - "dnssrv+_grpc._tcp.<service>.<namespace>.svc.cluster.local"
   #
+  # Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable).
+  serviceDiscoveryFiles: []
   # Names of configmaps that contain addresses of store API servers, used for file service discovery.
   serviceDiscoveryFileConfigMaps: []
   # Refresh interval to re-read file SD files. It is used as a resync fallback.

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -180,8 +180,8 @@ query:
   stores: []
   #  - "dnssrv+_grpc._tcp.<service>.<namespace>.svc.cluster.local"
   #
-  # Path to files that contains addresses of store API servers. The path can be a glob pattern (repeatable).
-  serviceDiscoveryFiles: []
+  # Names of configmaps that contain addresses of store API servers, used for file service discovery.
+  serviceDiscoveryFileConfigMaps: []
   # Refresh interval to re-read file SD files. It is used as a resync fallback.
   serviceDiscoveryInterval: 5m
   # Log filtering level.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?   | yes
| API breaks?     | no
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
This PR implements the file service discovery mechanism supported in Thanos Query by allowing one to create configmaps with store addresses and configure Query with those configmap names which automatically mounts them for Query to read.


### Why?
See above.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
I tested this locally by creating some configmaps and installing the helm chart.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
