### PR TITLE
[Thanos] Use existing secret for thanos objstore config

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.10
+version: 0.3.11
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.11
+version: 0.3.10
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.8
+version: 0.3.9
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.9
+version: 0.3.10
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -139,10 +139,9 @@ This section describes the values available
 | image.repository | Thanos image repository and name | 'quay.io/thanos/thanos'   **For Thanos version 0.6.0 or older change this to 'improbable/thanos'** |
 | image.tag | Thanos image tag | v0.8.1 |
 | image.pullPolicy | Image Kubernetes pull policy | IfNotPresent |
-| objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with objstoreFile. | {} |
-| objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with objstore. | "" |
-| objstoreSecret.useExistingSecret | Whether to skip secret creation in favor of an existing one | false |
-| objstoreSecret.secretName | The existing secret name | "" |
+| objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with other objstore options. | {} |
+| objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with other objstore options. | "" |
+| objstoreSecretOverride | Configuration for the backend object storage in an existing secret. Mutually exclusive with other objstore options.  | "" |
 
 ## Common settings for all components
 

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -141,6 +141,8 @@ This section describes the values available
 | image.pullPolicy | Image Kubernetes pull policy | IfNotPresent |
 | objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with objstoreFile. | {} |
 | objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with objstore. | "" |
+| objstoreSecret.useExistingSecret | Whether to skip secret creation in favor of an existing one | false |
+| objstoreSecret.secretName | The existing secret name | "" |
 
 ## Common settings for all components
 

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -66,8 +66,8 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          {{- if .Values.objstoreSecret.useExistingSecret }}
-          secretName: "{{ .Values.objstoreSecret.secretName }}"
+          {{- if .Values.objstoreSecretOverride }}
+          secretName: "{{ .Values.objstoreSecretOverride }}"
           {{- else }}
           secretName: {{ include "thanos.fullname" . }}
           {{- end }}

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -66,7 +66,11 @@ spec:
       volumes:
       - name: config-volume
         secret:
+          {{- if .Values.objstoreSecret.useExistingSecret }}
+          secretName: "{{ .Values.objstoreSecret.secretName }}"
+          {{- else }}
           secretName: {{ include "thanos.fullname" . }}
+          {{- end }}
         {{- with .Values.bucket.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -76,7 +76,11 @@ spec:
       {{- end }}
       - name: config-volume
         secret:
+          {{- if .Values.objstoreSecret.useExistingSecret }}
+          secretName: "{{ .Values.objstoreSecret.secretName }}"
+          {{- else }}
           secretName: {{ include "thanos.fullname" . }}
+          {{- end }}
       {{- with .Values.compact.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -76,8 +76,8 @@ spec:
       {{- end }}
       - name: config-volume
         secret:
-          {{- if .Values.objstoreSecret.useExistingSecret }}
-          secretName: "{{ .Values.objstoreSecret.secretName }}"
+          {{- if .Values.objstoreSecretOverride }}
+          secretName: "{{ .Values.objstoreSecretOverride }}"
           {{- else }}
           secretName: {{ include "thanos.fullname" . }}
           {{- end }}

--- a/thanos/templates/secret.yaml
+++ b/thanos/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.bucket.enabled .Values.store.enabled .Values.compact.enabled }}
+{{- if eq .Values.objstoreSecret.useExistingSecret false }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,4 +16,5 @@ data:
   {{- else }}
   object-store.yaml: {{ .Values.objstoreFile  | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/thanos/templates/secret.yaml
+++ b/thanos/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.bucket.enabled .Values.store.enabled .Values.compact.enabled }}
-{{- if eq .Values.objstoreSecret.useExistingSecret false }}
+{{- if eq .Values.objstoreSecretOverride "" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -113,7 +113,11 @@ spec:
         emptyDir: {}
       - name: config-volume
         secret:
+          {{- if $root.Values.objstoreSecret.useExistingSecret }}
+          secretName: "{{ $root.Values.objstoreSecret.secretName }}"
+          {{- else }}
           secretName: {{ include "thanos.fullname" $root }}
+          {{- end }}
       {{- if $root.Values.store.certSecretName }}
       - name: {{ $root.Values.store.certSecretName }}
         secret:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -113,8 +113,8 @@ spec:
         emptyDir: {}
       - name: config-volume
         secret:
-          {{- if $root.Values.objstoreSecret.useExistingSecret }}
-          secretName: "{{ $root.Values.objstoreSecret.secretName }}"
+          {{- if $root.Values.objstoreSecretOverride }}
+          secretName: "{{ $root.Values.objstoreSecretOverride }}"
           {{- else }}
           secretName: {{ include "thanos.fullname" $root }}
           {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -768,10 +768,8 @@ sidecar:
 
 # This is the general backend configuration. Please se the examples below to configurate object store.
 # More information can be found at thanos github repositoriy: https://github.com/thanos-io/thanos/blob/master/docs/storage.md
-# Existing secret containing the configuration
-objstoreSecret:
-  useExistingSecret: false
-  secretName: ""
+# Existing secret containing the configuration. The key must be `object-store.yaml`
+objstoreSecretOverride: ""
 # Text representation of the configuration
 objstoreFile: ""
 # YAML representation of the configuration. It's mutually exclusive with objstoreFile.

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -768,6 +768,10 @@ sidecar:
 
 # This is the general backend configuration. Please se the examples below to configurate object store.
 # More information can be found at thanos github repositoriy: https://github.com/thanos-io/thanos/blob/master/docs/storage.md
+# Existing secret containing the configuration
+objstoreSecret:
+  useExistingSecret: false
+  secretName: ""
 # Text representation of the configuration
 objstoreFile: ""
 # YAML representation of the configuration. It's mutually exclusive with objstoreFile.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no

### What's in this PR?
Added new key in objstore section
```yaml
# Existing secret containing the configuration
objstoreSecretOverride: "my-storage-config"
```
This setting affect the creation of the secret and their references in bucket, compact and store deployments.

It is empty by default so there are no breaking changes

### Why?
In order to use the same secret for thanos and prometheus charts, we must provide a way to get the objstore config form an existing secret. [Prometheus](https://github.com/helm/charts/tree/master/stable/prometheus-operator) is already setup that way, so this PR is a natural extension which completes the set.

### Checklist
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
