### PR TITLE
changed servicePort to use grpc

### DIFF
--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -78,6 +78,6 @@ spec:
         - path: {{ $.Values.store.grpc.ingress.path }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
-            servicePort: {{ $.Values.store.http.port }}
+            servicePort: {{ $.Values.store.grpc.port }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Updated servicePort in `store-ingress.yaml`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
the servicePort was incorrectly set to ```servicePort: {{ $.Values.store.http.port }}```

