### PR TITLE
Add pvc support for thanos-store

### DIFF
--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -110,7 +110,11 @@ spec:
           {{ toYaml $root.Values.store.resources | nindent 10 }}
       volumes:
       - name: data
+      {{- if $root.Values.store.dataVolume.backend }}
+        {{ toYaml $root.Values.store.dataVolume.backend | nindent 8 }}
+      {{- else }}
         emptyDir: {}
+      {{- end }}
       - name: config-volume
         secret:
           {{- if $root.Values.objstoreSecretOverride }}

--- a/thanos/templates/store-persistentvolumeclaim.yaml
+++ b/thanos/templates/store-persistentvolumeclaim.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.store.persistentVolumeClaim }}
+{{- $pvc := .Values.store.persistentVolumeClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $pvc.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: store
+{{ with .Values.store.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end -}}
+  {{- with .Values.store.deploymentAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $pvc.spec | nindent 2 }}
+{{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -32,6 +32,24 @@ store:
   #
   # Number of replicas running from store component
   replicaCount: 1
+  # Data volume for the thanos-store to store temporary data defaults to emptyDir
+  dataVolume:
+    backend: {}
+    #  persistentVolumeClaim:
+    #    claimName: store-data-volume
+  # Create the specified persistentVolumeClaim in case persistentVolumeClaim is
+  # used for the dataVolume.backend above and needs to be created.
+  persistentVolumeClaim: {}
+  #  name: store-data-volume
+  #  spec:
+  #    storageClassName: ""
+  #    accessModes: ["ReadWriteOnce"]
+  #    resources:
+  #      requests:
+  #        storage: 100Gi
+  #    selector: {}
+  #    volumeName: ""
+  #    volumeMode: ""
   # Extra labels for store pod template
   labels: {}
   #  cluster: example


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |no
| New feature?    |yes
| API breaks?     |no
| Deprecations?   |no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
Add Persistent Volume Support to thanos-store

### Why?
Store initially consumers disks to download indexes and if  indexes are huge , storing it in `emptydir{}` will cause pod to be evicted from the running node inorder avoid this chat must allow users to use Persistent Volumes for thanos-store


### Additional context
If indexes are huge even 10Gi would not be enough causing thanos-store pod to get evicted again n again.
