### PR TITLE
Cadence helm chart: Fix service annotations + Ingress YAML parsing

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.7.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -235,6 +235,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
 | `web.image.tag`                                   | WebUI image tag                                       | `3.3.2`               |
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
+| `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |
 | `web.service.port`                                | WebUI service port                                    | `80`                  |
 | `web.service.nodePort`                            | WebUI service nodePort, if service type is NodePort   | ``                    |

--- a/cadence/templates/web-ingress.yaml
+++ b/cadence/templates/web-ingress.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.web.ingress.enabled -}}
-{{- $serviceName := include "cadence.fullname" . -}}-web
-{{- $servicePort := .Values.web.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "cadence.componentname" (list . "web") }}
@@ -36,7 +34,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              serviceName: {{ include "cadence.fullname" $ }}-web
+              servicePort: {{ $.Values.web.service.port }}
   {{- end}}
 {{- end }}

--- a/cadence/templates/web-ingress.yaml
+++ b/cadence/templates/web-ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.web.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "cadence.componentname" (list . "web") }}

--- a/cadence/templates/web-service.yaml
+++ b/cadence/templates/web-service.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name }}
 {{- with .Values.web.service.annotations }}
   annotations:
-    {{- toYaml . | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
 {{- with .Values.web.service.loadBalancerIP }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | yes
| Related tickets | fixes #990 and #991 
| License         | Apache 2.0


### What's in this PR?
1. Document the cadence helm chart's `web-service` annotations.
1. Fix bug with YAML parsing of the cadence helm chart's `web-service` annotations.
1. Fix bug with YAML parsing of the cadence helm chart's `web-ingress` `apiVersion`.
1. Use updated `apiVersion` for the cadence helm chart's `web-ingress`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
