### PR TITLE
Add Elasticsearch as an option for searching support

### DIFF
--- a/cadence/templates/_helpers.tpl
+++ b/cadence/templates/_helpers.tpl
@@ -277,3 +277,40 @@ MySQL host.
 {{- define "mysql.host" -}}
 {{- printf "%s.%s.svc.cluster.local" (include "call-nested" (list . "mysql" "mysql.fullname")) .Release.Namespace -}}
 {{- end -}}
+
+{{/* Elasticsearch options.
+*/}}
+{{- define "cadence.advancedpersistence" -}}
+{{- if .Values.elasticsearch.enabled -}}
+{{- print "es-visibility" -}}
+{{- else -}}
+{{- print "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.elasticsearch.host" -}}
+{{- if (and (include "cadence.advancedpersistence" .) .Values.elasticsearch.host) -}}
+{{- print .Values.elasticsearch.host -}}
+{{- else if (include "cadence.advancedpersistence" . ) -}}
+{{- fail (print "Missing Elasticsearch host") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.elasticsearch.scheme" -}}
+{{- if (and (include "cadence.advancedpersistence" .) .Values.elasticsearch.scheme) -}}
+{{- print .Values.elasticsearch.scheme -}}
+{{- else if (include "cadence.advancedpersistence" . ) -}}
+{{- fail (print "Missing Elasticsearch scheme") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.elasticsearch.indices" -}}
+{{- if (and (include "cadence.advancedpersistence" .) .Values.elasticsearch.indices) -}}
+{{- if (lt (len .Values.elasticsearch.indices) 1) -}}
+{{- fail (print "Must have at least 1 Elasticsearch index") -}}
+{{- end -}}
+{{- .Values.elasticsearch.indices | toYaml -}}
+{{- else if (include "cadence.advancedpersistence" . ) -}}
+{{- fail (print "Missing Elasticsearch indices") -}}
+{{- end -}}
+{{- end -}}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -19,6 +19,9 @@ data:
       defaultStore: default
       visibilityStore: visibility
       numHistoryShards: {{ .Values.server.config.numHistoryShards }}
+      {{- if ( include "cadence.advancedpersistence" . ) }}
+      advancedVisibilityStore: {{ include  "cadence.advancedpersistence" . }}
+      {{- end }}
       datastores:
         default:
           {{- if eq (include "cadence.persistence.driver" (list . "default")) "cassandra" }}
@@ -64,6 +67,16 @@ data:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+
+        {{- if (include "cadence.advancedpersistence" .) }}
+        es-visiblity:
+          elasticsearch:
+            url:
+              host: {{ (include "cadence.elasticsearch.host" .) }}
+              scheme: {{ (include "cadence.elasticsearch.scheme" .) }}
+            indices:
+              {{ include "cadence.elasticsearch.indices" . }}
+        {{- end }}
 
     ringpop:
       name: cadence

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -258,3 +258,10 @@ mysql:
   initializationFiles:
     user.sql: |-
       GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';
+
+elasticsearch:
+  enabled: true
+  host: localhost:443
+  scheme: http
+  indices:
+    visibility: cadence-visibility


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #993
| License         | Apache 2.0


### What's in this PR?
This allows you to set an Elasticsearch endpoint to enable the search
API in Cadence.

It adds the following parameters to `values.yaml`:

| Parameter | Description | Default |
|-----------|-------------|--------|
| `elasticsearch.enabled` | Enable searching for workflows using an Elasticsearch cluster | `false` |
| `elasticsearch.scheme` | Scheme to use to connect to the Elasticsearch cluster | `http`|
| `elasticsearch.host` | Host to connect to | `` |
| `elasticsearch.indices` | Indices to use | `{}` |

These should match the relevant options that Cadence exposes for
configuring Elasticsearch.

Note that this does _not_ set up and configure an Elasticsearch
instance, but requires that you already have one set up and ready to go.


### Checklist
- [x] Related Helm chart(s) updated (if needed)
