### PR TITLE
[cadence] Use pod IP as service bind address

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.7.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -79,7 +79,7 @@ data:
       frontend:
         rpc:
           port: {{ include "cadence.frontend.internalPort" . }}
-          bindOnIP: "0.0.0.0"
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
             type: frontend
@@ -90,7 +90,7 @@ data:
       history:
         rpc:
           port: {{ include "cadence.history.internalPort" . }}
-          bindOnIP: "0.0.0.0"
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
             type: history
@@ -101,7 +101,7 @@ data:
       matching:
         rpc:
           port: {{ include "cadence.matching.internalPort" . }}
-          bindOnIP: "0.0.0.0"
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
             type: matching
@@ -112,7 +112,7 @@ data:
       worker:
         rpc:
           port: {{ include "cadence.worker.internalPort" . }}
-          bindOnIP: "0.0.0.0"
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
             type: worker

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -71,6 +71,10 @@ spec:
           image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
           imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: SERVICES
               value: {{ $service }}
             - name: CADENCE_STORE_PASSWORD


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #994
| License         | Apache 2.0


### What's in this PR?
This PR makes Cadence use the Pod IP instead of `0.0.0.0` as bind address.
