### PR TITLE
Update Thanos to v0.9.0

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.8.1
+appVersion: 0.9.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.11
+version: 0.3.12
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -116,8 +116,8 @@ Extra configuration for prometheus operator.
 prometheus:
   prometheusSpec:
     thanos:
-      image: quay.io/thanos/thanos:v0.8.1
-      version: v0.8.1
+      image: quay.io/thanos/thanos
+      version: v0.9.0
       objectStorageConfig:
         name: thanos
         key: object-store.yaml
@@ -137,7 +137,7 @@ This section describes the values available
 |Name|Description| Default Value|
 |----|-----------|--------------|
 | image.repository | Thanos image repository and name | 'quay.io/thanos/thanos'   **For Thanos version 0.6.0 or older change this to 'improbable/thanos'** |
-| image.tag | Thanos image tag | v0.8.1 |
+| image.tag | Thanos image tag | v0.9.0 |
 | image.pullPolicy | Image Kubernetes pull policy | IfNotPresent |
 | objstore | Configuration for the backend object storage in yaml format. Mutually exclusive with other objstore options. | {} |
 | objstoreFile | Configuration for the backend object storage in string format. Mutually exclusive with other objstore options. | "" |

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - "bucket"
           - "web"
           - "--log.level={{ .Values.bucket.logLevel }}"
-          - "--listen=0.0.0.0:{{ .Values.bucket.http.port }}"
+          - "--http-address=0.0.0.0:{{ .Values.bucket.http.port }}"
           - "--objstore.config-file=/etc/config/object-store.yaml"
           {{- if .Values.bucket.refresh }}
           - "--refresh={{ .Values.bucket.refresh }}"

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/thanos/thanos
-  tag: v0.8.1
+  tag: v0.9.0
   pullPolicy: IfNotPresent
 
 store:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
Updates chart to use the latest release of thanos [v0.9.0].  Only one change required -- related to `bucket web` params

### Why?
Updates chart to use the latest of thanos [v0.9.0]


### Checklist
- [x] User guide and development docs updated (if needed)
