### PR TITLE
Fix problems with Thanos Ruler statefulset

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.12
+version: 0.3.13
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: rule
+  serviceName: {{ include "thanos.name" . }}
   template:
     metadata:
       labels:
@@ -34,6 +35,7 @@ spec:
       - name: thanos-rule
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources: {{ toYaml .Values.rule.resources | nindent 10 }}
         {{- with .Values.rule.extraEnv }}
         env: {{ toYaml . | nindent 8 }}
         {{- end }}
@@ -115,14 +117,12 @@ spec:
       - name: rule-volume
         configMap:
           name: {{ include "thanos.fullname" . }}-rules
-      secretName: {{ include "thanos.fullname" . }}
       {{- if .Values.rule.livenessProbe }}
       livenessProbe: {{ toYaml .Values.rule.livenessProbe | nindent 8 }}
       {{- end }}
       {{- if .Values.rule.readinessProbe }}
       readinessProbe: {{ toYaml .Values.rule.readinessProbe | nindent 8 }}
       {{- end }}
-      resources: {{ toYaml .Values.rule.resources | nindent 8 }}
       {{- with .Values.rule.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | yes
| Deprecations?   | no|yes
| Related tickets | fixes #982 
| License         | Apache 2.0


### What's in this PR?

This commit fixes problems that occur when deploying Thanos Ruler using the BanzaiCloud Thanos Helm chart.

Problems identified when deploying on Helm 3 are:
- misuse of the field "resources" in StatefulSet.spec.template.spec
- misuse of the field "secretName" in StatefulSet.spec.template.spec
- omission of the field "serviceName" in StatefulSet.spec

The present commit moves "resources" up to the StatefulSet.spec.template.spec.containers field, where it is valid. It removes "secretName" entirely, since it does not exist anywhere in the StatefulSet API. Finally, it adds a serviceName, using the "thanos.name" value set.

### Why?

Addresses submitted issue https://github.com/banzaicloud/banzai-charts/issues/982.


### Additional context

There should be no problems deploying this same commit on any Helm under version 3, since there is no evidence that any Kubernetes version prior to the most recent version has these fields in the places where they can be found in this template. It is believed that previous versions of Helm were simply not reporting the error and allowing deployment to continue.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
