### PR TITLE
[thanos] update the sidecar configuration

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.12
+version: 0.3.13
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -16,6 +16,7 @@ metadata:
 {{ with .Values.sidecar.grpc.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: ClusterIP
+  externalIPs: {{- toYaml .Values.sidecar.grpc.service.externalIPs | nindent 4 }}
   clusterIP: None
   ports:
     - port: {{ .Values.sidecar.grpc.port }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -738,11 +738,11 @@ sidecar:
   grpc:
     # grpc listen port number
     port: 10901
-    # Service definition for bucket grpc service
+    # Service definition for sidecar grpc service
     service:
-      # Annotations to bucket grpc service
+      # Annotations to sidecar grpc service
       annotations: {}
-      # Labels to bucket grpc service
+      # Labels to sidecar grpc service
       labels: {}
     # Set up ingress for the grpc service
     ingress:
@@ -763,12 +763,12 @@ sidecar:
   http:
     # http listen port number
     port: 10902
-    # Service definition for bucket http service
+    # Service definition for sidecar http service
     service:
       type: ClusterIP
-      # Annotations to bucket http service
+      # Annotations to sidecar http service
       annotations: {}
-      # Labels to bucket http service
+      # Labels to sidecar http service
       labels: {}
     # Set up ingress for the http service
     ingress:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -740,6 +740,8 @@ sidecar:
     port: 10901
     # Service definition for sidecar grpc service
     service:
+      # External IPs assigned to sidecar grpc service
+      externalIPs: []
       # Annotations to sidecar grpc service
       annotations: {}
       # Labels to sidecar grpc service


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- fix typo in values.yaml comments for sidecar services
- add externalIPs configuration for sidecar grpc service

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Allow external IPs to be assigned to sidecar grpc service for external accesses. I understand this could be done through ingress, but the Nginx ingress controller doesn't support http2 without TLS (https://github.com/kubernetes/ingress-nginx/issues/4630) for grpc traffic, so this PR adds the alternative to expose the non-TLS sidecar grpc service.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Have tested locally with helm lint and install.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)

