### PR TITLE
MH - Fixed deployment templates for store, query, and compact - annot…

### DIFF
--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -28,9 +28,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: compact
 {{ with  .Values.compact.labels }}{{ toYaml . | indent 8 }}{{ end }}
-      {{- with  .Values.compact.annotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- if or .Values.compact.annotations .Values.compact.metrics.annotations.enabled }}
+      annotations:
       {{- end }}
+      {{- with  .Values.compact.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
       {{- if .Values.compact.metrics.annotations.enabled  }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.compact.http.port }}"

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -30,9 +30,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: query
 {{ with  .Values.query.labels }}{{ toYaml . | indent 8 }}{{ end }}
-      {{- with  .Values.query.annotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- if or .Values.query.annotations .Values.query.metrics.annotations.enabled }}
+      annotations:
       {{- end }}
+      {{- with  .Values.query.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
       {{- if .Values.query.metrics.annotations.enabled  }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.query.http.port }}"

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -33,9 +33,10 @@ spec:
         app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/component: store
         app.kubernetes.io/partition: "{{ $index }}"
-      {{- with  $root.Values.store.annotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- if or .Values.store.annotations .Values.store.metrics.annotations.enabled }}
+      annotations:
       {{- end }}
+      {{- with  $root.Values.store.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
       {{- if $root.Values.store.metrics.annotations.enabled  }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ $root.Values.store.http.port }}"

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/component: store
         app.kubernetes.io/partition: "{{ $index }}"
-      {{- if or .Values.store.annotations .Values.store.metrics.annotations.enabled }}
+      {{- if or $root.Values.store.annotations $root.Values.store.metrics.annotations.enabled }}
       annotations:
       {{- end }}
       {{- with  $root.Values.store.annotations }}{{ toYaml . | nindent 8 }}{{- end }}


### PR DESCRIPTION
Fixed metrics annotations - Previously they were creating labels instead of annotations.

| Q               | A
| --------------- | ---
| Bug fix?         |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Previously setting the component.metrics.annotations.enabled to true did not work - The deployment templates were broken and the annotations were being added as labels. I have changed the syntax in the deployment templates to add the `annotations:` heading if there are component.annotations or component.metrics.annotations.enabled. 


### Why?
Could not enable metrics on deployments without this fix


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist

- [X] Related Helm chart(s) updated (if needed)

