### PR TITLE
Add label selector matching for Thanos sidecar service.

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.15
+version: 0.3.16
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -307,7 +307,8 @@ timePartioning:
 
 |Name|Description| Default Value|
 |----|-----------|--------------|
-| sidecar.enabled | NOTE: This is only the service references for the sidecar. It will create a service looking for `app: prometheus` labels| true |
+| sidecar.enabled | NOTE: This is only the service references for the sidecar. | true |
+| sidecar.selector | Pod label selector to match sidecar services on. | `{"app": "prometheus"}` |
 
 ## Contributing
 Contributions are very welcome!

--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -24,7 +24,7 @@ spec:
       targetPort: grpc
       name: grpc
   selector:
-    app: prometheus
+    {{ toYaml .Values.sidecar.selector | nindent 4 }}
 
 ---
 
@@ -54,5 +54,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: prometheus
+    {{ toYaml .Values.sidecar.selector | nindent 4 }}
 {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -739,6 +739,8 @@ rule:
 sidecar:
   # NOTE: This is only the service references for the sidecar
   enabled: true
+  selector:
+    app: prometheus
   # Enable metrics collecting for compat service
   metrics:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added the ability to adapt the sidecar service pod label selectors.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Allows for the possibility to more granularly match on pods this service intends to target.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)