### PR TITLE
Fix indentation for Prometheus metrics annotations

### DIFF
--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -38,8 +38,8 @@ spec:
       {{- end }}
       {{- with  $root.Values.store.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
       {{- if $root.Values.store.metrics.annotations.enabled  }}
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ $root.Values.store.http.port }}"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ $root.Values.store.http.port }}"
       {{- end }}
     spec:
       containers:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fixes indentation for Prometheus metrics annotations for store-deployment resource.


### Why?
Annotations won't work with the current indentation, hence Prometheus metrics won't be enabled for Thanos Store.



