### PR TITLE
Add rule servicemonitor template

### DIFF
--- a/thanos/templates/rule-servicemonitor.yaml
+++ b/thanos/templates/rule-servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.rule.enabled .Values.rule.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "thanos.componentname" (list $ "rule") }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: rule
+{{ with .Values.rule.metrics.serviceMonitor.labels }}{{ toYaml . | indent 4 }}{{ end }}
+spec:
+  jobLabel: thanos-rule
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "thanos.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: rule
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.rule.metrics.serviceMonitor.interval | default "15s" }}
+      {{- with .Values.rule.metrics.serviceMonitor.relabellings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| License         | Apache 2.0


### What's in this PR?
Adds a servicemonitor template for the rule component.


### Why?
The rule servicemonitor is configurable in values.yaml but the template is missing.
