### PR TITLE
Add secret override functionality to rule component

### DIFF
--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -114,7 +114,11 @@ spec:
         emptyDir: {}
       - name: config-volume
         secret:
+          {{- if .Values.objstoreSecretOverride }}
+          secretName: "{{ .Values.objstoreSecretOverride }}"
+          {{- else }}
           secretName: {{ include "thanos.fullname" . }}
+          {{- end }}
       - name: rule-volume
         configMap:
           name: {{ include "thanos.fullname" . }}-rules


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fixes the issue that the rule statefulset template does not consider the `objstoreSecretOverride` variable.


### Why?
Aligns with other deployments/statefulsets.
