### PR TITLE
[thanos] parameterize sidecar grpc service type and add nodePort value

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.17
+version: 0.3.18
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/sidecar-service.yaml
+++ b/thanos/templates/sidecar-service.yaml
@@ -15,11 +15,16 @@ metadata:
     app.kubernetes.io/component: sidecar
 {{ with .Values.sidecar.grpc.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.sidecar.grpc.service.type }}
   externalIPs: {{- toYaml .Values.sidecar.grpc.service.externalIPs | nindent 4 }}
+  {{- if eq .Values.sidecar.grpc.service.type "ClusterIP" }}
   clusterIP: None
+  {{- end }}
   ports:
     - port: {{ .Values.sidecar.grpc.port }}
+      {{- if eq .Values.sidecar.grpc.service.type "NodePort" }}
+      nodePort: {{ .Values.sidecar.grpc.service.nodePort }}
+      {{- end }}
       protocol: TCP
       targetPort: grpc
       name: grpc

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -819,7 +819,7 @@ objstoreSecretOverride: ""
 # Text representation of the configuration
 objstoreFile: ""
 # YAML representation of the configuration. It's mutually exclusive with objstoreFile.
-objstore:
+objstore: {}
   # type: GCS
   # config:
   #   bucket: "thanos"

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -764,6 +764,9 @@ sidecar:
     port: 10901
     # Service definition for sidecar grpc service
     service:
+      type: ClusterIP
+      # The node port number to use when the service type is set as 'NodePort'
+      nodePort: 31901
       # External IPs assigned to sidecar grpc service
       externalIPs: []
       # Annotations to sidecar grpc service


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. add default empty map {} to 'objstore' in Thanos values.yaml to prevent the helm 3 warning.

2. allow Thanos sidecar grpc service to be set as other types than ClusterIP (e.g. NodePort).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

have locally tested with helm lint and install

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
