### PR TITLE
Add pods labels & annotations in ruler template

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.17
+version: 0.3.18
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -30,6 +30,10 @@ spec:
         app.kubernetes.io/name: {{ include "thanos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: rule
+{{ with  .Values.rule.labels }}{{ toYaml . | indent 8 }}{{ end }}
+      {{- with  .Values.rule.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: thanos-rule


### PR DESCRIPTION
Signed-off-by: Joffrey Janiec <jjaniec@student.42.fr>

| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds the ability to specify custom annotations & labels for the thanos ruler statufulset's pods, which is already possible for the other thanos components, but not for this one

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Specifying annotations is mandatory if we want to give the thanos ruler an iam role with kube2iam 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The default values were already present in the values.yaml file, but were not used in the chart template

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)

