### PR TITLE
thanos ruler: fix cert secret handling

### DIFF
--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -118,6 +118,12 @@ spec:
       - name: rule-volume
         configMap:
           name: {{ include "thanos.fullname" . }}-rules
+      {{- if .Values.rule.certSecretName }}
+      - name: {{ .Values.rule.certSecretName }}
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.rule.certSecretName }}
+      {{- end }}
       {{- if .Values.rule.livenessProbe }}
       livenessProbe: {{ toYaml .Values.rule.livenessProbe | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This PR fixes handling of certificate secrets for the thanos ruler component. 
So far it is possible for all other components to add a secret to be automatically mounted to /etc/certs. This functionality was only partially implemented for the ruler component.


### Why?
Without being able to mount a secret containing certificates it is not possible to set up tls based encryption and authentication for the ruler component.


### Additional context
The required values were already present in the values.yaml for the ruler component
but only partially used. The volume mount did try to mount the secret, but a corresponding volume definition was missing.


### Checklist
- [x] Related Helm chart(s) updated (if needed)
