### PR TITLE
Support configuring update strategy

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.17
+version: 0.3.18
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -154,6 +154,8 @@ These setting applicable to nearly all components.
 | $component.deploymentLabels | Additional labels to the deployment | {} |
 | $component.deploymentAnnotations | Additional annotations to the deployment | {} |
 | $component.extraEnv | Add extra environment variables | [] |
+| $component.strategy | Kubernetes [deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) object | {} |
+| $component.updateStrategy | Kubernetes [statefulset update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) object | {} |
 | $component.metrics.annotations.enabled | Prometheus annotation for component | false |
 | $component.metrics.serviceMonitor.enabled | Prometheus ServiceMonitor definition for component | false |
 | $component.securityContext | SecurityContext for Pod | {} |

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.bucket.replicaCount | default 1 }}
+  {{- with  .Values.bucket.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.compact.replicaCount | default 1 }}
+  {{- with  .Values.compact.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -15,9 +15,12 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if not .Values.query.autoscaling.enabled  }}
+  {{- if not .Values.query.autoscaling.enabled  }}
   replicas: {{ .Values.query.replicaCount | default 1 }}
-{{- end }}
+  {{- end }}
+  {{- with  .Values.query.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -18,6 +18,9 @@ spec:
   {{- if not .Values.rule.autoscaling.enabled }}
   replicas: {{ .Values.rule.replicaCount | default 1 }}
   {{- end }}
+  {{- with  .Values.rule.updateStrategy }}
+  updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ $root.Values.store.replicaCount | default 1 }}
+  {{- with  $root.Values.store.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" $root }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -34,6 +34,8 @@ store:
   #
   # Number of replicas running from store component
   replicaCount: 1
+  # Kubernetes deployment strategy object as documented in https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
   # Data volume for the thanos-store to store temporary data defaults to emptyDir
   dataVolume:
     backend: {}
@@ -221,6 +223,8 @@ query:
   #
   # Number of replicas running from query component
   replicaCount: 1
+  # Kubernetes deployment strategy object as documented in https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
   # Enable HPA for query component
   autoscaling:
     enabled: false
@@ -377,6 +381,8 @@ compact:
   extraArgs:
   # - "--extraargs=extravalue"
   #
+  # Kubernetes deployment strategy object as documented in https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
   # Data volume for the compactor to store temporary data defaults to emptyDir
   dataVolume:
     backend: {}
@@ -498,6 +504,8 @@ bucket:
   extraArgs:
   # - "--extraargs=extravalue"
   #
+  # Kubernetes deployment strategy object as documented in https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
   # Extra labels for bucket pod template
   labels: {}
   #  cluster: example
@@ -622,6 +630,8 @@ rule:
   #
   # Number of replicas running from rule component
   replicaCount: 1
+  # Kubernetes update strategy object as documented in https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategy: {}
   # Enable HPA for rule component
   autoscaling:
     enabled: false


### PR DESCRIPTION
Signed-off-by: Alex Gaganov <alex.gaganov@fiverr.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?  | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?

This PR allows providing a custom `strategy`|`updateStrategy` object to better control how deployments/statefulsets are being updated. The value defaults to `{}` and it's up to the chart user to override it according to Kubernetes documentation: [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy), [statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies). 

### Why?

If not specified, the update strategy for deployments is `RollingUpdate`, and in case compactor or store pods have a PVC associated with them, the rolling update will hang indefinitely, as the volume is already assigned to the old pod. Setting the update strategy to `Recreate` will first terminate the pod and then launch a replacement, thus letting the update complete. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- IMO, a more holistic approach would be to convert compactor and store to be statefulsets. 
