### PR TITLE
[thanos] check .Values.sidecar.enable in secret creation

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.18
+version: 0.3.19
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/secret.yaml
+++ b/thanos/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.bucket.enabled .Values.store.enabled .Values.compact.enabled }}
+{{- if or .Values.bucket.enabled .Values.store.enabled .Values.compact.enabled .Values.sidecar.enabled }}
 {{- if eq .Values.objstoreSecretOverride "" }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Check .Values.sidecar.enable in secret.yaml. When it's set, secret.yaml should be created.

I have a use case where only sidecar in this chart is enabled, just to collect and ship local prometheus metrics to S3. In this case, I'd like to use this chart to create secret for S3 as well.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Have locally tested with helm lint and install.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
