### PR TITLE
Added affinity templating to dex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.lock
 *.tgz
 index.yaml
-.DS_Store*.swp
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.lock
 *.tgz
 index.yaml
-.DS_Store
+.DS_Store*.swp

--- a/dex/Chart.yaml
+++ b/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.6.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 icon: https://raw.githubusercontent.com/dexidp/dex/master/Documentation/logos/dex-glyph-color.png

--- a/dex/README.md
+++ b/dex/README.md
@@ -52,6 +52,7 @@ The following table lists configurable parameters of the dex chart and their def
 |config.staticClients                 |client config (use config file see below)    |[]                                        |
 |config.connectors                    |connectors config (use config file see below)|[]                                        |
 |nodeSelector                         |nodeselector                                 |{}                                        |
+|affinity                             |affinity                                     |{}                                        |
 |ingress.enabled                      |ingress enabled                              |false                                     |
 |ingress.annotations                  |ingress annotations                          |{}                                        |
 |ingress.hosts                        |ingress hosts                                |["/"]                                     |

--- a/dex/templates/deployment.yaml
+++ b/dex/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 10 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 10 }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/dex/values.yaml
+++ b/dex/values.yaml
@@ -104,6 +104,8 @@ config:
 
 nodeSelector: {}
 
+affinity: {}
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?
Templates affinity into the dex chart. Allows users to define affinity set in values.yml


### Why?
This is useful for HA etc, it allows me to spread pods across multiple AZs in AWS. Affinity gives more granular control than nodeSelector

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

