### PR TITLE
add "component: server" to sidecar selector

### DIFF
--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -761,6 +761,7 @@ sidecar:
   enabled: true
   selector:
     app: prometheus
+    component: server
   # Enable metrics collecting for compat service
   metrics:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
Qualify the selector for the sidecar pod to the prometheus server component.

### Why?
Sidecar is usually running with the server.  Without this qualification, pods of other components like pushgateway or node_exporter will match.
