### PR TITLE
thanos: Add selector matchLabels for thanos services

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.18
+version: 0.3.19
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -165,6 +165,7 @@ These setting applicable to nearly all components.
 | $component.affinity | [Pod affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity) | {} |
 | $component.grpc.port | grpc listen port number | 10901 |
 | $component.grpc.service.annotations | Service definition for grpc service | {} |
+| $component.grpc.service.matchLabels | Pod label selector to match grpc service on. | `{}` |
 | $component.grpc.ingress.enabled | Set up ingress for the grpc service | false |
 | $component.grpc.ingress.annotations | Add annotations to ingress | {} |
 | $component.grpc.ingress.labels | Add labels to ingress | {} |
@@ -173,6 +174,7 @@ These setting applicable to nearly all components.
 | $component.grpc.ingress.tls | Ingress TLS configuration | [] |
 | $component.http.port | http listen port number | 10902 |
 | $component.http.service.annotations | Service definition for http service | {} |
+| $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
 | $component.http.ingress.enabled | Set up ingress for the http service | false |
 | $component.http.ingress.annotations | Add annotations to ingress | {} |
 | $component.http.ingress.labels | Add labels to ingress | {} |

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: bucket
+{{ with .Values.bucket.deploymentMatchLabels }}{{ toYaml . | indent 4 }}{{ end }}
   template:
     metadata:
       labels:

--- a/thanos/templates/bucket-service.yaml
+++ b/thanos/templates/bucket-service.yaml
@@ -24,4 +24,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: bucket
+{{ with .Values.bucket.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{ end }}

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: compact
+{{ with .Values.compact.deploymentMatchLabels }}{{ toYaml . | indent 4 }}{{ end }}
   template:
     metadata:
       labels:

--- a/thanos/templates/compact-service.yaml
+++ b/thanos/templates/compact-service.yaml
@@ -24,4 +24,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: compact
+{{ with .Values.compact.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{ end}}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query
+{{ with .Values.query.deploymentMatchLabels }}{{ toYaml . | indent 4 }}{{ end }}
   template:
     metadata:
       labels:

--- a/thanos/templates/query-service.yaml
+++ b/thanos/templates/query-service.yaml
@@ -26,6 +26,7 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{ with .Values.query.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -58,4 +59,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{ with .Values.query.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{- end -}}

--- a/thanos/templates/rule-service.yaml
+++ b/thanos/templates/rule-service.yaml
@@ -26,6 +26,7 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: rule
+{{ with .Values.rule.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -43,7 +44,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: rule
-  {{ with .Values.store.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
+  {{ with .Values.rule.http.service.labels }}{{ toYaml . | indent 4 }}{{ end }}
 spec:
   type: {{ .Values.rule.http.service.type }}
   {{- if .Values.rule.http.service.externalTrafficPolicy }}
@@ -58,4 +59,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: rule
-  {{- end }}
+{{ with .Values.rule.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
+{{- end }}

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: rule
-{{ with .Values.rule.statefulsetLabel }}{{ toYaml . | indent 4 }}{{ end -}}
+{{ with .Values.rule.statefulsetLabels }}{{ toYaml . | indent 4 }}{{ end -}}
   {{- with .Values.rule.statefulsetAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -26,6 +26,7 @@ spec:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: rule
+{{ with .Values.rule.statefulsetMatchLabels }}{{ toYaml . | indent 4 }}{{ end }}
   serviceName: {{ include "thanos.name" . }}
   template:
     metadata:

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       app.kubernetes.io/instance: {{ $.Release.Name }}
       app.kubernetes.io/component: store
       app.kubernetes.io/partition: "{{ $index }}"
+{{ with $root.Values.store.deploymentMatchLabels }}{{ toYaml . | indent 4 }}{{ end }}
   template:
     metadata:
       labels:

--- a/thanos/templates/store-service.yaml
+++ b/thanos/templates/store-service.yaml
@@ -26,6 +26,7 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{ with .Values.store.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -58,4 +59,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{ with .Values.store.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{- end -}}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -69,7 +69,10 @@ store:
   # Add extra annotations to store deployment
   deploymentAnnotations: {}
   #  extraAnnotation: extraAnnotationValue
-  # Enable metrics collecting for compat service
+  #
+  # Add extra selector matchLabels to store deployment
+  deploymentMatchLabels: {}
+  # Enable metrics collecting for store service
   metrics:
     # This is the Prometheus annotation type scraping configuration
     annotations:
@@ -316,9 +319,10 @@ query:
   deploymentAnnotations: {}
   #  extraAnnotation: extraAnnotationValue
   #
-  # Enable metrics collecting for compat service
-
-
+  # Add extra selector matchLabels to query deployment
+  deploymentMatchLabels: {}
+  #
+  # Enable metrics collecting for query service
   metrics:
     # This is the Prometheus annotation type scraping configuration
     annotations:
@@ -427,7 +431,10 @@ compact:
   deploymentAnnotations: {}
   #  extraAnnotation: extraAnnotationValue
   #
-  # Enable metrics collecting for compat service
+  # Add extra selector matchLabels to compact deployment
+  deploymentMatchLabels: {}
+  #
+  # Enable metrics collecting for compact service
   metrics:
     # This is the Prometheus annotation type scraping configuration
     annotations:
@@ -532,6 +539,9 @@ bucket:
   #
   # Add extra annotations to bucket deployment
   deploymentAnnotations: {}
+  #
+  # Add extra selector matchLabels to bucket deployment
+  deploymentMatchLabels: {}
 
   # Enable podDisruptionBudget for bucket component
   podDisruptionBudget:
@@ -731,9 +741,10 @@ rule:
   statefulsetAnnotations: {}
   #  extraAnnotation: extraAnnotationValue
   #
-  # Enable metrics collecting for compat service
-
-
+  #
+  # Add extra selector matchLabels to rule deployment
+  statefulsetMatchLabels: {}
+  # Enable metrics collecting for rule service
   metrics:
     # This is the Prometheus annotation type scraping configuration
     annotations:
@@ -777,7 +788,7 @@ sidecar:
   enabled: true
   selector:
     app: prometheus
-  # Enable metrics collecting for compat service
+  # Enable metrics collecting for sidecar service
   metrics:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator
     serviceMonitor:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -89,6 +89,8 @@ store:
       annotations: {}
       # Labels to query grpc service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -115,6 +117,8 @@ store:
       annotations: {}
       # Labels to query http service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -247,8 +251,10 @@ query:
     service:
       # Annotations to query grpc service
       annotations: {}
-      # labels to query grpc service
+      # Labels to query grpc service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -276,6 +282,8 @@ query:
       annotations: {}
       # Labels to query http service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -372,6 +380,8 @@ compact:
     port: 10902
     service:
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
   # Add extra environment variables to compact
   extraEnv:
   # - name: ENV
@@ -481,6 +491,8 @@ bucket:
       annotations: {}
       # Labels to bucket http service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -656,6 +668,8 @@ rule:
       annotations: {}
       # labels to rule grpc service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -683,6 +697,8 @@ rule:
       annotations: {}
       # Labels to rule http service
       labels: {}
+      # Match labels for service selector
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds selector `matchLabels` option to thanos services to allow custom labels to match services on as well as to thanos deployments. Included a few README and other typo fixes.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
For scenarios where there may be multiples of the same thanos components running in a namespace, custom label selectors are necessary.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
