### PR TITLE
spot-termination-exporter: Add missing selector field

### DIFF
--- a/spot-termination-exporter/Chart.yaml
+++ b/spot-termination-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: spot-termination-exporter
 home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/banzai-charts
-version: 0.0.7
+version: 0.0.8
 description: Spot Termination exporter Helm chart for Kubernetes
 keywords:
 - spot

--- a/spot-termination-exporter/templates/daemonset.yaml
+++ b/spot-termination-exporter/templates/daemonset.yaml
@@ -8,7 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-
+  selector:
+    matchLabels:
+      app: {{ template "spotTerminationexporter.fullname" . }}
+      component: "{{ template "spotTerminationexporter.fullname" . }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
### What's in this PR?

The DaemonSetSpec v1/apps requires the selector's matchLabel field to
match the labels of the pods. As such, add the missing field to make
the deployment work with the new API.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1087
| License         | Apache 2.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
