### PR TITLE
Update traefik chart version

### DIFF
--- a/pipeline-cluster-ingress/Chart.yaml
+++ b/pipeline-cluster-ingress/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: Ingress controller to deploy on clusters managed by Banzai Cloud Pipeline
 name: pipeline-cluster-ingress
-version: 0.0.9
+version: 0.0.10
+appVersion: "1.7.20"
 keywords:
   - pipeline
   - cluster

--- a/pipeline-cluster-ingress/requirements.yaml
+++ b/pipeline-cluster-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: traefik
-  version: 1.63.0
+  version: 1.86.2
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/pipeline/pull/2894
| License         | Apache 2.0


### What's in this PR?
The old traefik version (1.7.9) doesn't work properly with K8s version 1.18.