### PR TITLE
alerting_rules.yml => alerting_rules.yaml in example values

### DIFF
--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -625,7 +625,7 @@ rule:
   ruleOverrideName: ""
   # Rule files for rule
   ruleFiles:
-    alerting_rules.yml: {}
+    alerting_rules.yaml: {}
     # groups:
     #   - name: Instances
     #     rules:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
fix to the example value -- rulers deployed with this chart will look for `.yaml` rule files, not `.yml` as per https://github.com/banzaicloud/banzai-charts/blob/master/thanos/templates/rule-statefulset.yaml#L58


### Why?
it's annoying to debug why no rules are showing up despite following instructions to a T


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ X ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ X ] Logging code meets the guideline (TODO)
- [ X ] User guide and development docs updated (if needed)
- [ X ] Related Helm chart(s) updated (if needed)
