### PR TITLE
Add statsd support to the Cadence configmap

### DIFF
--- a/cadence/README.md
+++ b/cadence/README.md
@@ -237,6 +237,7 @@ Global options overridable per service are marked with an asterisk.
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |
 | `server.metrics.serviceMonitor.enabled`*          | Enable Prometheus ServiceMonitor                      | `false`               |
 | `server.metrics.prometheus.timerType`*            | Prometheus timer type                                 | `histogram`           |
+| `server.metrics.statsd.hostPort`*                 | Statsd daemon host and port                           | ``                    |
 | `server.podAnnotations`*                          | Server pod annotations                                | `{}`                  |
 | `server.resources`*                               | Server CPU/Memory resource requests/limits            | `{}`                  |
 | `server.nodeSelector`*                            | Node labels for pod assignment                        | `{}`                  |
@@ -252,6 +253,7 @@ Global options overridable per service are marked with an asterisk.
 | `server.[service].metrics.annotations.enabled`    | Annotate `[service]` pods with Prometheus annotations | ``                    |
 | `server.[service].metrics.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for `[service]`      | ``                    |
 | `server.[service].metrics.prometheus.timerType`   | `[service]` Prometheus timer type                     | ``                    |
+| `server.[service].metrics.statsd.hostPort`        | `[service]` Statsd daemon host and port               | ``                    |
 | `server.[service].podAnnotations`                 | `[service]` pod annotations                           | `{}`                  |
 | `server.[service].resources`                      | `[service]` CPU/Memory resource requests/limits       | `{}`                  |
 | `server.[service].nodeSelector`                   | `[service]` Node labels for pod assignment            | `{}`                  |

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -86,6 +86,11 @@ data:
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.frontend.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
+          {{- if or .Values.server.metrics.statsd .Values.server.frontend.metrics.statsd }}
+            statsd:
+              hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.frontend.metrics.statsd.hostPort | quote }}
+              prefix: "cadence.frontend"
+          {{- end}}
 
       history:
         rpc:
@@ -97,6 +102,11 @@ data:
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.history.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
+          {{- if or .Values.server.metrics.statsd .Values.server.history.metrics.statsd }}
+            statsd:
+              hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.history.metrics.statsd.hostPort | quote }}
+              prefix: "cadence.history"
+          {{- end}}
 
       matching:
         rpc:
@@ -108,6 +118,11 @@ data:
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.matching.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
+          {{- if or .Values.server.metrics.statsd .Values.server.matching.metrics.statsd }}
+            statsd:
+              hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.matching.metrics.statsd.hostPort | quote }}
+              prefix: "cadence.matching"
+          {{- end}}
 
       worker:
         rpc:
@@ -119,6 +134,11 @@ data:
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
+          {{- if or .Values.server.metrics.statsd .Values.server.worker.metrics.statsd }}
+            statsd:
+              hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.worker.metrics.statsd.hostPort | quote }}
+              prefix: "cadence.worker"
+          {{- end}}
 
     clusterMetadata:
       enableGlobalDomain: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -25,6 +25,9 @@ server:
       interval: 30s
     prometheus:
       timerType: histogram
+    statsd: {}
+      #   hostPort: localhost:8125
+
   podAnnotations: {}
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -120,6 +123,8 @@ server:
         # enabled: false
       prometheus: {}
         # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
     podAnnotations: {}
     resources: {}
     nodeSelector: {}
@@ -138,6 +143,8 @@ server:
         # enabled: false
       prometheus: {}
         # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
     podAnnotations: {}
     resources: {}
     nodeSelector: {}
@@ -156,6 +163,8 @@ server:
         # enabled: false
       prometheus: {}
         # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
     podAnnotations: {}
     resources: {}
     nodeSelector: {}
@@ -174,6 +183,8 @@ server:
         # enabled: false
       prometheus: {}
         # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
     podAnnotations: {}
     resources: {}
     nodeSelector: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/banzai-charts/issues/1097
| License         | Apache 2.0


### What's in this PR?
Cadence supports [statsd metrics](https://github.com/uber/cadence/blob/27dcc419a54ab23391cacd164c4dfab5f4d79585/common/service/config/config.go#L318-L330) but the helm chart did not provide a way to enable it. This adds that support.

### Why?
Adds statsd metrics as an option in the config map and values. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] (N/A for helm charts?) Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
