### PR TITLE
Feature/multiple replica labels [Thanos]

### DIFF
--- a/thanos/README.md
+++ b/thanos/README.md
@@ -232,7 +232,7 @@ timePartioning:
 | query.replicaCount | Pod replica count | 1 |
 | query.logLevel | Log level | info |
 | query.logFormat | Log format to use. Possible options: logfmt or json. | logfmt |
-| query.replicaLabel | Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter. | "" |
+| query.replicaLabel | Labels to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter. | [] |
 | query.autoDownsampling | Enable --query.auto-downsampling option for query. | false |
 | query.webRoutePrefix |Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus. | "" |
 | query.webExternalPrefix |Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path | "" |

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - "--log.format={{ .Values.query.logFormat }}"
         - "--grpc-address=0.0.0.0:{{ .Values.query.grpc.port }}"
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
-        {{- range .Values.query.replicaLabel }}
+        {{- range .Values.query.replicaLabels }}
         - "--query.replica-label={{ . }}"
         {{- end }}
         {{- if .Values.query.autoDownsampling }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -56,8 +56,8 @@ spec:
         - "--log.format={{ .Values.query.logFormat }}"
         - "--grpc-address=0.0.0.0:{{ .Values.query.grpc.port }}"
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
-        {{- if .Values.query.replicaLabel }}
-        - "--query.replica-label={{ .Values.query.replicaLabel }}"
+        {{- range .Values.query.replicaLabel }}
+        - "--query.replica-label={{ . }}"
         {{- end }}
         {{- if .Values.query.autoDownsampling }}
         - "--query.auto-downsampling"

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -906,4 +906,3 @@ objstore: {}
   #   container: ""
   #   endpoint: ""
   #   max_retries: 0
-

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -177,7 +177,7 @@ query:
   enabled: true
   # Labels to treat as a replica indicator along which data is deduplicated.
   # Still you will be able to query without deduplication using 'dedup=false' parameter.
-  replicaLabel: []
+  replicaLabels: []
   # - replica
   # - prometheus_replica
   #

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -177,7 +177,7 @@ query:
   enabled: true
   # Labels to treat as a replica indicator along which data is deduplicated.
   # Still you will be able to query without deduplication using 'dedup=false' parameter.
-  replicaLabel: {}
+  replicaLabel: []
   # - replica
   # - prometheus_replica
   #

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -175,9 +175,12 @@ store:
 
 query:
   enabled: true
-  # Label to treat as a replica indicator along which data is deduplicated.
+  # Labels to treat as a replica indicator along which data is deduplicated.
   # Still you will be able to query without deduplication using 'dedup=false' parameter.
-  replicaLabel: ""
+  replicaLabel: {}
+  # - replica
+  # - prometheus_replica
+  #
   # Enable --query.auto-downsampling option for query.
   autoDownsampling: false
   # Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path.
@@ -903,3 +906,4 @@ objstore: {}
   #   container: ""
   #   endpoint: ""
   #   max_retries: 0
+


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none I guess
| License         | Apache 2.0


### What's in this PR?
This PR makes a change from a single string of `query.replicaLabel` to a list. Also updated the readme for this.


### Why?
We need this in order to use multiple values of `replicaLabel` which gets passed on as an argument `--query.replica-label=` 
As Thanos supports multiple arguments, we can change the string to a list. 

See: https://github.com/thanos-io/thanos/pull/1362

### Additional context
This will be a breaking change as we move from string to list.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

