### PR TITLE
[Thanos] Respect rule override configmap

### DIFF
--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -129,7 +129,11 @@ spec:
           {{- end }}
       - name: rule-volume
         configMap:
+          {{- if empty .Values.rule.ruleOverrideName -}}
           name: {{ include "thanos.fullname" . }}-rules
+          {{- else }}
+          name: {{ .Values.rule.ruleOverrideName }}
+          {{- end }}
       {{- if .Values.rule.certSecretName }}
       - name: {{ .Values.rule.certSecretName }}
         secret:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -625,7 +625,7 @@ rule:
   ruleOverrideName: ""
   # Rule files for rule
   ruleFiles:
-    alerting_rules.yml: {}
+    alerting_rules.yaml: {}
     # groups:
     #   - name: Instances
     #     rules:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
as per the [documentation](https://github.com/banzaicloud/banzai-charts/blob/master/thanos/README.md):
`rule.ruleOverrideName | Override rules file with custom configmap`

while this appears to have been the intended behavior, we always mount `{{ include "thanos.fullname" . }}-rules` as the `rule-volume`, and moreover if you _do_ specify a `ruleOverrideName` we [dont create that CM](https://github.com/banzaicloud/banzai-charts/blob/master/thanos/templates/rule-configmap.yaml#L1) and the pod cant start.

this adds a check to use the override on startup if specified, else use the default


### Why?
so i can use a custom configmap for my rules

### Additional context
non


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ x ] User guide and development docs updated (if needed)
- [ x ] Related Helm chart(s) updated (if needed)
