### PR TITLE
Fix indentation for thanos store deployment probes

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.21
+version: 0.3.22
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -106,11 +106,11 @@ spec:
         {{- end }}
         {{- if $root.Values.store.livenessProbe }}
         livenessProbe:
-        {{ toYaml $root.Values.store.livenessProbe | nindent 8 }}
+        {{ toYaml $root.Values.store.livenessProbe | nindent 10 }}
         {{- end }}
         {{- if $root.Values.store.readinessProbe }}
         readinessProbe:
-        {{ toYaml $root.Values.store.readinessProbe | nindent 8 }}
+        {{ toYaml $root.Values.store.readinessProbe | nindent 10 }}
         {{- end }}
         resources:
           {{ toYaml $root.Values.store.resources | nindent 10 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | f
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Currently it's not possible to set liveness and readiness probes for Thanos sture (due to indentation bug), however documentation mentions them.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Fixes indentation for liveness/readiness probes for Thanos store.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Steps to reproduce:
1. Render the Thanos chart setting a probe property - `helm template --set store.livenessProbe.initialDelaySeconds=3 thanos/`
2. Check the output for store deployment, without this patch properties aren't rendered under property object
3. Switch to this PR and check again ``helm template --set store.livenessProbe.initialDelaySeconds=3 thanos/``


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
