### PR TITLE
Version bump and fix for startup

### DIFF
--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         env: {{ toYaml . | nindent 8 }}
         {{- end }}
         args:
+          - "tools"
           - "bucket"
           - "web"
           - "--log.level={{ .Values.bucket.logLevel }}"

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/thanos/thanos
-  tag: v0.10.1
+  tag: v0.13.0
   pullPolicy: IfNotPresent
 
 store:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | fixes #1104
| License         | Apache 2.0


### What's in this PR?
Changes to support newer version of thanos. 

### Why?
When using thanos 13, the bucket pod would be stuck crashing due to the missing argument.

### Checklist
- [ x] Related Helm chart(s) updated (if needed)
