### PR TITLE
Add kubefed

### DIFF
--- a/kubefed/.helmignore
+++ b/kubefed/.helmignore
@@ -1,0 +1,3 @@
+# Ignore common backup files
+*.swp
+*~

--- a/kubefed/Chart.yaml
+++ b/kubefed/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: KubeFed helm chart
+name: kubefed
+version: 0.2.0-banzai.1

--- a/kubefed/Chart.yaml
+++ b/kubefed/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: KubeFed helm chart
 name: kubefed
-version: 0.2.0-banzai.1
+version: 0.3.1-banzai.1

--- a/kubefed/LICENSE
+++ b/kubefed/LICENSE
@@ -1,0 +1,202 @@
+
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Istio Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kubefed/README.md
+++ b/kubefed/README.md
@@ -1,0 +1,161 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Kubernetes Cluster Federation](#kubernetes-cluster-federation)
+  - [Prerequisites](#prerequisites)
+  - [Installing the Chart](#installing-the-chart)
+  - [Uninstalling the Chart](#uninstalling-the-chart)
+  - [Configuration](#configuration)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Kubernetes Cluster Federation
+
+Kubernetes Cluster Federation is a Kubernetes Incubator project. It builds on the sync controller
+(a.k.a. push reconciler) from [Federation v1](https://github.com/kubernetes/federation/)
+to iterate on the API concepts laid down in the [brainstorming
+doc](https://docs.google.com/document/d/159cQGlfgXo6O4WxXyWzjZiPoIuiHVl933B43xhmqPEE/edit#)
+and further refined in the [architecture
+doc](https://docs.google.com/document/d/1ihWETo-zE8U_QNuzw5ECxOWX0Df_2BVfO3lC4OesKRQ/edit#).
+Access to both documents is available to members of the
+[kubernetes-sig-multicluster google
+group](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster).
+
+## Prerequisites
+
+- Kubernetes 1.13+
+- Helm 2.10+
+
+## Configuring RBAC for Helm (Optional)
+
+If your Kubernetes cluster has RBAC enabled, it will be necessary to
+ensure that helm is deployed with a service account with the
+permissions necessary to deploy KubeFed:
+
+```bash
+$ cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+EOF
+
+$ helm init --service-account tiller
+```
+
+## Installing the Chart
+
+First, add the KubeFed chart repo to your local repository.
+```bash
+$ helm repo add kubefed-charts https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
+
+$ helm repo list
+NAME            URL
+kubefed-charts   https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
+```
+
+With the repo added, available charts and versions can be viewed.
+```bash
+$ helm search kubefed --devel
+```
+
+Install the chart and specify the version to install with the
+`--version` argument. Replace `<x.x.x>` with your desired version.
+```bash
+$ helm install kubefed-charts/kubefed --name kubefed --version=<x.x.x> --namespace kube-federation-system --devel
+```
+
+**NOTE:** For **namespace-scoped deployments** (configured with the `--set
+global.scope=Namespaced` option in the `helm install` command): if you created
+your namespace prior to installing the chart, make sure to **add a `name:
+<namespace>` label to the namespace** using the following command:
+
+```bash
+kubectl label namespaces <namespace> name=<namespace>
+```
+
+This label is necessary to get proper validation for KubeFed core APIs. If the
+namespace does not already exist, the `helm install` command will create the
+namespace with this label by default.
+
+## Uninstalling the Chart
+
+Due to this helm [issue](https://github.com/helm/helm/issues/4440), the CRDs cannot be deleted
+when delete helm release, so before delete the helm release, we need first delete all
+of the CR and CRDs for KubeFed release.
+
+Delete all KubeFed `FederatedTypeConfig`:
+
+```bash
+$ kubectl -n kube-federation-system delete FederatedTypeConfig --all
+```
+
+Delete all KubeFed CRDs:
+
+```bash
+$ kubectl delete crd $(kubectl get crd | grep -E 'kubefed.io' | awk '{print $1}')
+```
+
+Then you can uninstall/delete the `kubefed` release:
+
+```bash
+$ helm delete --purge kubefed
+```
+
+The command above removes all the Kubernetes components associated with the chart
+and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the KubeFed
+chart and their default values.
+
+| Parameter                             | Description                                                                                                                                                                                 | Default                         |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------|
+| controllermanager.enabled             | Specifies whether to enable the controller manager in KubeFed.                                                                                                                              | true                            |
+| controllermanager.replicaCount        | Number of replicas for KubeFed controller manager.                                                                                                                                          | 2                               |
+| controllermanager.repository          | Repo of the KubeFed image.                                                                                                                                                                  | quay.io/kubernetes-multicluster |
+| controllermanager.image               | Name of the KubeFed image.                                                                                                                                                                  | kubefed                         |
+| controllermanager.tag                 | Tag of the KubeFed image.                                                                                                                                                                   | latest                          |
+| controllermanager.imagePullPolicy     | Image pull policy.                                                                                                                                                                          | IfNotPresent                    |
+| controllermanager.featureGates.PushReconciler               | Push reconciler feature.                                                                                                                                              | true                            |
+| controllermanager.featureGates.SchedulerPreferences         | Scheduler preferences feature.                                                                                                                                        | true                            |
+| controllermanager.featureGates.CrossClusterServiceDiscovery | Cross cluster service discovery feature.                                                                                                                              | true                            |
+| controllermanager.featureGates.FederatedIngress             | Federated ingress feature.                                                                                                                                            | true                            |
+| controllermanager.clusterAvailableDelay   | Time to wait before reconciling on a healthy cluster.                                                                                                                                   | 20s                             |
+| controllermanager.clusterUnavailableDelay | Time to wait before giving up on an unhealthy cluster.                                                                                                                                  | 60s                             |
+| controllermanager.leaderElectLeaseDuration | The maximum duration that a leader can be stopped before it is replaced by another candidate.                                                                                          | 15s                             |
+| controllermanager.leaderElectRenewDeadline | The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to `controllermanager.LeaderElectLeaseDuration. | 10s                             |
+| controllermanager.leaderElectRetryPeriod   | The duration the clients should wait between attempting acquisition and renewal of a leadership.                                                                                       | 5s                              |
+| controllermanager.leaderElectResourceLock  | The type of resource object that is used for locking during leader election. Supported options are `configmaps` and `endpoints`.                                                       | configmaps                      |
+| controllermanager.clusterHealthCheckPeriod           | How often to monitor the cluster health.                                                                                                                                     | 10s                              |
+| controllermanager.clusterHealthCheckFailureThreshold | Minimum consecutive failures for the cluster health to be considered failed after having succeeded.                                                                          | 3                               |
+| controllermanager.clusterHealthCheckSuccessThreshold | Minimum consecutive successes for the cluster health to be considered successful after having failed.                                                                        | 1                               |
+| controllermanager.clusterHealthCheckTimeout          | Duration after which the cluster health check times out.                                                                                                                     | 3s                               |
+| controllermanager.syncController.adoptResources  | Whether to adopt pre-existing resource in member clusters.                                                                                                        		          | Enabled                         |
+| global.scope                   | Whether the KubeFed namespace will be the only target for the control plane.                                                                                                                           | Cluster                         |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example:
+
+```bash
+$ helm install kubefed-charts/kubefed --name kubefed --namespace kube-federation-system --values values.yaml --devel
+```

--- a/kubefed/charts/controllermanager/Chart.yaml
+++ b/kubefed/charts/controllermanager/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.0.2"
+description: A Helm chart for KubeFed Controller Manager
+name: controllermanager
+version: 0.0.2

--- a/kubefed/charts/controllermanager/crds/crds.yaml
+++ b/kubefed/charts/controllermanager/crds/crds.yaml
@@ -1,0 +1,1139 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterpropagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: ClusterPropagatedVersion
+    listKind: ClusterPropagatedVersionList
+    plural: clusterpropagatedversions
+    singular: clusterpropagatedversion
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterPropagatedVersion holds version information about the state
+        propagated from KubeFed APIs (configured by FederatedTypeConfig resources)
+        to member clusters. The name of a ClusterPropagatedVersion encodes the kind
+        and name of the resource it stores information for (i.e. <lower-case kind>-<resource
+        name>). If a target resource has a populated metadata.Generation field, the
+        generation will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedservicestatuses.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedServiceStatus
+    listKind: FederatedServiceStatusList
+    plural: federatedservicestatuses
+    singular: federatedservicestatus
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        clusterStatus:
+          items:
+            description: FederatedServiceClusterStatus is the observed status of the
+              resource for a named cluster
+            properties:
+              clusterName:
+                type: string
+              status:
+                description: ServiceStatus represents the current status of a service.
+                properties:
+                  loadBalancer:
+                    description: LoadBalancer contains the current status of the load-balancer,
+                      if one is present.
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - status
+            type: object
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedtypeconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedTypeConfig
+    listKind: FederatedTypeConfigList
+    plural: federatedtypeconfigs
+    shortNames:
+    - ftc
+    singular: federatedtypeconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "FederatedTypeConfig programs KubeFed to know about a single API
+        type - the \"target type\" - that a user wants to federate. For each target
+        type, there is a corresponding FederatedType that has the following fields:
+        \n - The \"template\" field specifies the basic definition of a federated
+        resource - The \"placement\" field specifies the placement information for
+        the federated   resource - The \"overrides\" field specifies how the target
+        resource should vary across   clusters."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FederatedTypeConfigSpec defines the desired state of FederatedTypeConfig.
+          properties:
+            federatedType:
+              description: Configuration for the federated type that defines (via
+                template, placement and overrides fields) how the target type should
+                appear in multiple cluster.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            propagation:
+              description: Whether or not propagation to member clusters should be
+                enabled.
+              type: string
+            statusCollection:
+              description: Whether or not Status object should be populated.
+              type: string
+            statusType:
+              description: Configuration for the status type that holds information
+                about which type holds the status of the federated resource. If not
+                provided, the group and version will default to those provided for
+                the federated type api resource.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            targetType:
+              description: The configuration of the target type. If not set, the pluralName
+                and groupName fields will be set from the metadata.name of this resource.
+                The kind field must be set.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+          required:
+          - federatedType
+          - propagation
+          - targetType
+          type: object
+        status:
+          description: FederatedTypeConfigStatus defines the observed state of FederatedTypeConfig
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the FederatedTypeConfig.
+              format: int64
+              type: integer
+            propagationController:
+              description: PropagationController tracks the status of the sync controller.
+              type: string
+            statusController:
+              description: StatusController tracks the status of the status controller.
+              type: string
+          required:
+          - observedGeneration
+          - propagationController
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubefedclusters.core.kubefed.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: ready
+    type: string
+  group: core.kubefed.io
+  names:
+    kind: KubeFedCluster
+    listKind: KubeFedClusterList
+    plural: kubefedclusters
+    singular: kubefedcluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeFedCluster configures KubeFed to be aware of a Kubernetes cluster
+        and encapsulates the details necessary to communicate with the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedClusterSpec defines the desired state of KubeFedCluster
+          properties:
+            apiEndpoint:
+              description: The API endpoint of the member cluster. This can be a hostname,
+                hostname:port, IP or IP:port.
+              type: string
+            caBundle:
+              description: CABundle contains the certificate authority information.
+              format: byte
+              type: string
+            disabledTLSValidations:
+              description: DisabledTLSValidations defines a list of checks to ignore
+                when validating the TLS connection to the member cluster.  This can
+                be any of *, SubjectName, or ValidityPeriod. If * is specified, it
+                is expected to be the only option in list.
+              items:
+                type: string
+              type: array
+            secretRef:
+              description: Name of the secret containing the token required to access
+                the member cluster. The secret needs to exist in the same namespace
+                as the control plane and should have a "token" key.
+              properties:
+                name:
+                  description: Name of a secret within the enclosing namespace
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - apiEndpoint
+          - secretRef
+          type: object
+        status:
+          description: KubeFedClusterStatus contains information about the current
+            status of a cluster updated periodically by cluster controller.
+          properties:
+            conditions:
+              description: Conditions is an array of current cluster conditions.
+              items:
+                description: ClusterCondition describes current state of a cluster.
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of cluster condition, Ready or Offline.
+                    type: string
+                required:
+                - lastProbeTime
+                - status
+                - type
+                type: object
+              type: array
+            region:
+              description: Region is the name of the region in which all of the nodes
+                in the cluster exist.  e.g. 'us-east1'.
+              type: string
+            zones:
+              description: Zones are the names of availability zones in which the
+                nodes of the cluster exist, e.g. 'us-east1-a'.
+              items:
+                type: string
+              type: array
+          required:
+          - conditions
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubefedconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: KubeFedConfig
+    listKind: KubeFedConfigList
+    plural: kubefedconfigs
+    singular: kubefedconfig
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedConfigSpec defines the desired state of KubeFedConfig
+          properties:
+            clusterHealthCheck:
+              properties:
+                failureThreshold:
+                  description: Minimum consecutive failures for the cluster health
+                    to be considered failed after having succeeded.
+                  format: int64
+                  type: integer
+                period:
+                  description: How often to monitor the cluster health.
+                  type: string
+                successThreshold:
+                  description: Minimum consecutive successes for the cluster health
+                    to be considered successful after having failed.
+                  format: int64
+                  type: integer
+                timeout:
+                  description: Duration after which the cluster health check times
+                    out.
+                  type: string
+              type: object
+            controllerDuration:
+              properties:
+                availableDelay:
+                  description: Time to wait before reconciling on a healthy cluster.
+                  type: string
+                unavailableDelay:
+                  description: Time to wait before giving up on an unhealthy cluster.
+                  type: string
+              type: object
+            featureGates:
+              items:
+                properties:
+                  configuration:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - configuration
+                - name
+                type: object
+              type: array
+            leaderElect:
+              properties:
+                leaseDuration:
+                  description: The duration that non-leader candidates will wait after
+                    observing a leadership renewal until attempting to acquire leadership
+                    of a led but unrenewed leader slot. This is effectively the maximum
+                    duration that a leader can be stopped before it is replaced by
+                    another candidate. This is only applicable if leader election
+                    is enabled.
+                  type: string
+                renewDeadline:
+                  description: The interval between attempts by the acting master
+                    to renew a leadership slot before it stops leading. This must
+                    be less than or equal to the lease duration. This is only applicable
+                    if leader election is enabled.
+                  type: string
+                resourceLock:
+                  description: The type of resource object that is used for locking
+                    during leader election. Supported options are `configmaps` (default)
+                    and `endpoints`.
+                  type: string
+                retryPeriod:
+                  description: The duration the clients should wait between attempting
+                    acquisition and renewal of a leadership. This is only applicable
+                    if leader election is enabled.
+                  type: string
+              type: object
+            scope:
+              description: The scope of the KubeFed control plane should be either
+                `Namespaced` or `Cluster`. `Namespaced` indicates that the KubeFed
+                namespace will be the only target of the control plane.
+              type: string
+            syncController:
+              properties:
+                adoptResources:
+                  description: Whether to adopt pre-existing resources in member clusters.
+                    Defaults to "Enabled".
+                  type: string
+              type: object
+          required:
+          - scope
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: propagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: PropagatedVersion
+    listKind: PropagatedVersionList
+    plural: propagatedversions
+    singular: propagatedversion
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PropagatedVersion holds version information about the state propagated
+        from KubeFed APIs (configured by FederatedTypeConfig resources) to member
+        clusters. The name of a PropagatedVersion encodes the kind and name of the
+        resource it stores information for (i.e. <lower-case kind>-<resource name>).
+        If a target resource has a populated metadata.Generation field, the generation
+        will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsendpoints.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DNSEndpoint is the CRD wrapper for Endpoint which is designed to
+        act as a source of truth for external-dns.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DNSEndpointSpec defines the desired state of DNSEndpoint
+          properties:
+            endpoints:
+              items:
+                description: Endpoint is a high-level association between a service
+                  and an IP.
+                properties:
+                  dnsName:
+                    description: The FQDN of the DNS record.
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels stores labels defined for the Endpoint.
+                    type: object
+                  recordTTL:
+                    description: TTL for the record in seconds.
+                    format: int64
+                    type: integer
+                  recordType:
+                    description: RecordType type of record, e.g. CNAME, A, SRV, TXT
+                      etc.
+                    type: string
+                  targets:
+                    description: The targets that the DNS record points to.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          description: DNSEndpointStatus defines the observed state of DNSEndpoint
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the DNSEndpoint.
+              format: int64
+              type: integer
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: domains.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: Domain
+    listKind: DomainList
+    plural: domains
+    singular: domain
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        domain:
+          description: Domain is the DNS zone associated with the KubeFed control
+            plane
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        nameServer:
+          description: NameServer is the authoritative DNS name server for the KubeFed
+            domain
+          type: string
+      required:
+      - domain
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressdnsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: IngressDNSRecord
+    listKind: IngressDNSRecordList
+    plural: ingressdnsrecords
+    singular: ingressdnsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IngressDNSRecordSpec defines the desired state of IngressDNSRecord
+          properties:
+            hosts:
+              description: Host from the IngressRule in Cluster Ingress Spec
+              items:
+                type: string
+              type: array
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for the Ingress, if omitted a default would be used
+              format: int64
+              type: integer
+          type: object
+        status:
+          description: IngressDNSRecordStatus defines the observed state of IngressDNSRecord
+          properties:
+            dns:
+              description: Array of Ingress Controller LoadBalancers
+              items:
+                description: ClusterIngressDNS defines the observed status of Ingress
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding ingress controller
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicednsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: ServiceDNSRecord
+    listKind: ServiceDNSRecordList
+    plural: servicednsrecords
+    singular: servicednsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "ServiceDNSRecord defines a scheme of DNS name and subdomains that
+        should be programmed with endpoint information about a Service deployed in
+        multiple Kubernetes clusters. ServiceDNSRecord is name-associated with the
+        Services it programs endpoint information for, meaning that a ServiceDNSRecord
+        expresses the intent to program DNS with information about endpoints for the
+        Kubernetes Service resources with the same name and namespace in different
+        clusters. \n For the example, given the following values: \n metadata.name:
+        test-service metadata.namespace: test-namespace spec.federationName: test-federation
+        \n the following set of DNS names will be programmed: \n Global Level: test-service.test-namespace.test-federation.svc.<federation-domain>
+        Region Level: test-service.test-namespace.test-federation.svc.(status.DNS[*].region).<federation-domain>
+        Zone Level  : test-service.test-namespace.test-federation.svc.(status.DNS[*].zone).(status.DNS[*].region).<federation-domain>
+        \n Optionally, when DNSPrefix is specified, another DNS name will be programmed
+        which would be a CNAME record pointing to DNS name at global level as below:
+        <dns-prefix>.<federation-domain> --> test-service.test-namespace.test-federation.svc.<federation-domain>"
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceDNSRecordSpec defines the desired state of ServiceDNSRecord.
+          properties:
+            allowServiceWithoutEndpoints:
+              description: AllowServiceWithoutEndpoints allows DNS records to be written
+                for Service shards without endpoints
+              type: boolean
+            dnsPrefix:
+              description: DNSPrefix when specified, an additional DNS record would
+                be created with <DNSPrefix>.<KubeFedDomain>
+              type: string
+            domainRef:
+              description: DomainRef is the name of the domain object to which the
+                corresponding federated service belongs
+              type: string
+            externalName:
+              description: ExternalName when specified, replaces the service name
+                portion of a resource record with the value of ExternalName.
+              type: string
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for this Service, if omitted a default would be used
+              format: int64
+              type: integer
+          required:
+          - domainRef
+          type: object
+        status:
+          description: ServiceDNSRecordStatus defines the observed state of ServiceDNSRecord.
+          properties:
+            dns:
+              items:
+                description: ClusterDNS defines the observed status of LoadBalancer
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding service
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  region:
+                    description: Region to which the cluster belongs
+                    type: string
+                  zones:
+                    description: Zones to which the cluster belongs
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            domain:
+              description: Domain is the DNS domain of the KubeFed control plane as
+                in Domain API
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: replicaschedulingpreferences.scheduling.kubefed.io
+spec:
+  group: scheduling.kubefed.io
+  names:
+    kind: ReplicaSchedulingPreference
+    listKind: ReplicaSchedulingPreferenceList
+    plural: replicaschedulingpreferences
+    singular: replicaschedulingpreference
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReplicaSchedulingPreferenceSpec defines the desired state of
+            ReplicaSchedulingPreference
+          properties:
+            clusters:
+              additionalProperties:
+                description: Preferences regarding number of replicas assigned to
+                  a cluster workload object (dep, rs, ..) within a federated workload
+                  object.
+                properties:
+                  maxReplicas:
+                    description: Maximum number of replicas that should be assigned
+                      to this cluster workload object. Unbounded if no value provided
+                      (default).
+                    format: int64
+                    type: integer
+                  minReplicas:
+                    description: Minimum number of replicas that should be assigned
+                      to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                  weight:
+                    description: A number expressing the preference to put an additional
+                      replica to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                type: object
+              description: A mapping between cluster names and preferences regarding
+                a local workload object (dep, rs, .. ) in these clusters. "*" (if
+                provided) applies to all clusters if an explicit mapping is not provided.
+                If omitted, clusters without explicit preferences should not have
+                any replicas scheduled.
+              type: object
+            rebalance:
+              description: If set to true then already scheduled and running replicas
+                may be moved to other clusters in order to match current state to
+                the specified preferences. Otherwise, if set to false, up and running
+                replicas will not be moved.
+              type: boolean
+            targetKind:
+              description: TODO (@irfanurrehman); upgrade this to label selector only
+                if need be. The idea of this API is to have a a set of preferences
+                which can be used for a target FederatedDeployment or FederatedReplicaset.
+                Although the set of preferences in question can be applied to multiple
+                target objects using label selectors, but there are no clear advantages
+                of doing that as of now. To keep the implementation and usage simple,
+                matching ns/name of RSP resource to the target resource is sufficient
+                and only additional information needed in RSP resource is a target
+                kind (FederatedDeployment or FederatedReplicaset).
+              type: string
+            totalReplicas:
+              description: Total number of pods desired across federated clusters.
+                Replicas specified in the spec for target deployment template or replicaset
+                template will be discarded/overridden when scheduling preferences
+                are specified.
+              format: int32
+              type: integer
+          required:
+          - targetKind
+          - totalReplicas
+          type: object
+        status:
+          description: ReplicaSchedulingPreferenceStatus defines the observed state
+            of ReplicaSchedulingPreference
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/kubefed/charts/controllermanager/templates/_helpers.tpl
+++ b/kubefed/charts/controllermanager/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "controllermanager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "controllermanager.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "controllermanager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
+++ b/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
@@ -1,0 +1,130 @@
+{{- if or (not .Values.global.scope) (eq .Values.global.scope "Cluster") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kubefed-admin
+rules:
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: kubefed-edit
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - update
+  - delete
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubefed-view
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}

--- a/kubefed/charts/controllermanager/templates/clusterrole.yaml
+++ b/kubefed/charts/controllermanager/templates/clusterrole.yaml
@@ -1,0 +1,97 @@
+{{- if or (not .Values.global.scope) (eq .Values.global.scope "Cluster") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+  name: kubefed-role
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+{{- end }}
+---
+# This role provides the necessary permissions to create admission reviews.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+# TODO(font) For namespace scoped deployments, create a unique cluster-scoped
+# resource name using the namespace. This is needed because helm does not
+# currently support the ability to share resources across multiple
+# installations of the same chart. Additionally, admission-webhooks do not
+# currently support the ability to have namespace-scoped RBAC permissions only.
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: system:kubefed:{{ .Release.Namespace }}:admission-requester
+{{ else }}
+  name: system:kubefed:admission-requester
+{{ end }}
+rules:
+- apiGroups:
+  - validation.core.kubefed.io
+  resources:
+  - federatedtypeconfigs
+  - kubefedclusters
+  - kubefedconfigs
+  verbs:
+  - create
+- apiGroups:
+  - mutation.core.kubefed.io
+  resources:
+  - kubefedconfigs
+  verbs:
+  - create

--- a/kubefed/charts/controllermanager/templates/clusterrolebindings.yaml
+++ b/kubefed/charts/controllermanager/templates/clusterrolebindings.yaml
@@ -1,0 +1,63 @@
+{{- if or (not .Values.global.scope) (eq .Values.global.scope "Cluster") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubefed-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubefed-role
+subjects:
+- kind: ServiceAccount
+  name: kubefed-controller
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+# For namespace scoped deployments, create a unique cluster-scoped resource
+# name using the namespace. This is needed because admission-webhooks do not
+# currently support the ability to have namespace-scoped RBAC permissions only.
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: kubefed-admission-webhook:{{ .Release.Namespace }}:auth-delegator
+{{ else }}
+  name: kubefed-admission-webhook:auth-delegator
+{{ end }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kubefed-admission-webhook
+  namespace: {{ .Release.Namespace }}
+---
+# This clusterrolebinding grants permissions for the admission webhook to create
+# admission reviews on behalf of the system:anonymous user.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+# TODO(font) For namespace scoped deployments, create a unique cluster-scoped
+# resource name using the namespace. This is needed because helm does not
+# currently support the ability to share resources across multiple
+# installations of the same chart. Additionally, admission-webhooks do not
+# currently support the ability to have namespace-scoped RBAC permissions only.
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: kubefed-admission-webhook:{{ .Release.Namespace }}:anonymous-auth
+{{ else }}
+  name: kubefed-admission-webhook:anonymous-auth
+{{ end }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: system:kubefed:{{ .Release.Namespace }}:admission-requester
+{{ else }}
+  name: system:kubefed:admission-requester
+{{ end }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:anonymous

--- a/kubefed/charts/controllermanager/templates/crds.yaml
+++ b/kubefed/charts/controllermanager/templates/crds.yaml
@@ -1,0 +1,1198 @@
+{{ if (or (or (not .Values.global.scope) (eq .Values.global.scope "Cluster")) (not (.Capabilities.APIVersions.Has "core.kubefed.io/v1beta1"))) }}
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: clusterpropagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: ClusterPropagatedVersion
+    listKind: ClusterPropagatedVersionList
+    plural: clusterpropagatedversions
+    singular: clusterpropagatedversion
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterPropagatedVersion holds version information about the state
+        propagated from KubeFed APIs (configured by FederatedTypeConfig resources)
+        to member clusters. The name of a ClusterPropagatedVersion encodes the kind
+        and name of the resource it stores information for (i.e. <lower-case kind>-<resource
+        name>). If a target resource has a populated metadata.Generation field, the
+        generation will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: federatedservicestatuses.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedServiceStatus
+    listKind: FederatedServiceStatusList
+    plural: federatedservicestatuses
+    singular: federatedservicestatus
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        clusterStatus:
+          items:
+            description: FederatedServiceClusterStatus is the observed status of the
+              resource for a named cluster
+            properties:
+              clusterName:
+                type: string
+              status:
+                description: ServiceStatus represents the current status of a service.
+                properties:
+                  loadBalancer:
+                    description: LoadBalancer contains the current status of the load-balancer,
+                      if one is present.
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - status
+            type: object
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: federatedtypeconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedTypeConfig
+    listKind: FederatedTypeConfigList
+    plural: federatedtypeconfigs
+    shortNames:
+    - ftc
+    singular: federatedtypeconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "FederatedTypeConfig programs KubeFed to know about a single API
+        type - the \"target type\" - that a user wants to federate. For each target
+        type, there is a corresponding FederatedType that has the following fields:
+        \n - The \"template\" field specifies the basic definition of a federated
+        resource - The \"placement\" field specifies the placement information for
+        the federated   resource - The \"overrides\" field specifies how the target
+        resource should vary across   clusters."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FederatedTypeConfigSpec defines the desired state of FederatedTypeConfig.
+          properties:
+            federatedType:
+              description: Configuration for the federated type that defines (via
+                template, placement and overrides fields) how the target type should
+                appear in multiple cluster.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            propagation:
+              description: Whether or not propagation to member clusters should be
+                enabled.
+              type: string
+            statusCollection:
+              description: Whether or not Status object should be populated.
+              type: string
+            statusType:
+              description: Configuration for the status type that holds information
+                about which type holds the status of the federated resource. If not
+                provided, the group and version will default to those provided for
+                the federated type api resource.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            targetType:
+              description: The configuration of the target type. If not set, the pluralName
+                and groupName fields will be set from the metadata.name of this resource.
+                The kind field must be set.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+          required:
+          - federatedType
+          - propagation
+          - targetType
+          type: object
+        status:
+          description: FederatedTypeConfigStatus defines the observed state of FederatedTypeConfig
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the FederatedTypeConfig.
+              format: int64
+              type: integer
+            propagationController:
+              description: PropagationController tracks the status of the sync controller.
+              type: string
+            statusController:
+              description: StatusController tracks the status of the status controller.
+              type: string
+          required:
+          - observedGeneration
+          - propagationController
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: kubefedclusters.core.kubefed.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: ready
+    type: string
+  group: core.kubefed.io
+  names:
+    kind: KubeFedCluster
+    listKind: KubeFedClusterList
+    plural: kubefedclusters
+    singular: kubefedcluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeFedCluster configures KubeFed to be aware of a Kubernetes cluster
+        and encapsulates the details necessary to communicate with the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedClusterSpec defines the desired state of KubeFedCluster
+          properties:
+            apiEndpoint:
+              description: The API endpoint of the member cluster. This can be a hostname,
+                hostname:port, IP or IP:port.
+              type: string
+            caBundle:
+              description: CABundle contains the certificate authority information.
+              format: byte
+              type: string
+            disabledTLSValidations:
+              description: DisabledTLSValidations defines a list of checks to ignore
+                when validating the TLS connection to the member cluster.  This can
+                be any of *, SubjectName, or ValidityPeriod. If * is specified, it
+                is expected to be the only option in list.
+              items:
+                type: string
+              type: array
+            secretRef:
+              description: Name of the secret containing the token required to access
+                the member cluster. The secret needs to exist in the same namespace
+                as the control plane and should have a "token" key.
+              properties:
+                name:
+                  description: Name of a secret within the enclosing namespace
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - apiEndpoint
+          - secretRef
+          type: object
+        status:
+          description: KubeFedClusterStatus contains information about the current
+            status of a cluster updated periodically by cluster controller.
+          properties:
+            conditions:
+              description: Conditions is an array of current cluster conditions.
+              items:
+                description: ClusterCondition describes current state of a cluster.
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of cluster condition, Ready or Offline.
+                    type: string
+                required:
+                - lastProbeTime
+                - status
+                - type
+                type: object
+              type: array
+            region:
+              description: Region is the name of the region in which all of the nodes
+                in the cluster exist.  e.g. 'us-east1'.
+              type: string
+            zones:
+              description: Zones are the names of availability zones in which the
+                nodes of the cluster exist, e.g. 'us-east1-a'.
+              items:
+                type: string
+              type: array
+          required:
+          - conditions
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: kubefedconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: KubeFedConfig
+    listKind: KubeFedConfigList
+    plural: kubefedconfigs
+    singular: kubefedconfig
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedConfigSpec defines the desired state of KubeFedConfig
+          properties:
+            clusterHealthCheck:
+              properties:
+                failureThreshold:
+                  description: Minimum consecutive failures for the cluster health
+                    to be considered failed after having succeeded.
+                  format: int64
+                  type: integer
+                period:
+                  description: How often to monitor the cluster health.
+                  type: string
+                successThreshold:
+                  description: Minimum consecutive successes for the cluster health
+                    to be considered successful after having failed.
+                  format: int64
+                  type: integer
+                timeout:
+                  description: Duration after which the cluster health check times
+                    out.
+                  type: string
+              type: object
+            controllerDuration:
+              properties:
+                availableDelay:
+                  description: Time to wait before reconciling on a healthy cluster.
+                  type: string
+                unavailableDelay:
+                  description: Time to wait before giving up on an unhealthy cluster.
+                  type: string
+              type: object
+            featureGates:
+              items:
+                properties:
+                  configuration:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - configuration
+                - name
+                type: object
+              type: array
+            leaderElect:
+              properties:
+                leaseDuration:
+                  description: The duration that non-leader candidates will wait after
+                    observing a leadership renewal until attempting to acquire leadership
+                    of a led but unrenewed leader slot. This is effectively the maximum
+                    duration that a leader can be stopped before it is replaced by
+                    another candidate. This is only applicable if leader election
+                    is enabled.
+                  type: string
+                renewDeadline:
+                  description: The interval between attempts by the acting master
+                    to renew a leadership slot before it stops leading. This must
+                    be less than or equal to the lease duration. This is only applicable
+                    if leader election is enabled.
+                  type: string
+                resourceLock:
+                  description: The type of resource object that is used for locking
+                    during leader election. Supported options are `configmaps` (default)
+                    and `endpoints`.
+                  type: string
+                retryPeriod:
+                  description: The duration the clients should wait between attempting
+                    acquisition and renewal of a leadership. This is only applicable
+                    if leader election is enabled.
+                  type: string
+              type: object
+            scope:
+              description: The scope of the KubeFed control plane should be either
+                `Namespaced` or `Cluster`. `Namespaced` indicates that the KubeFed
+                namespace will be the only target of the control plane.
+              type: string
+            syncController:
+              properties:
+                adoptResources:
+                  description: Whether to adopt pre-existing resources in member clusters.
+                    Defaults to "Enabled".
+                  type: string
+              type: object
+          required:
+          - scope
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: propagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: PropagatedVersion
+    listKind: PropagatedVersionList
+    plural: propagatedversions
+    singular: propagatedversion
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PropagatedVersion holds version information about the state propagated
+        from KubeFed APIs (configured by FederatedTypeConfig resources) to member
+        clusters. The name of a PropagatedVersion encodes the kind and name of the
+        resource it stores information for (i.e. <lower-case kind>-<resource name>).
+        If a target resource has a populated metadata.Generation field, the generation
+        will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: dnsendpoints.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DNSEndpoint is the CRD wrapper for Endpoint which is designed to
+        act as a source of truth for external-dns.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DNSEndpointSpec defines the desired state of DNSEndpoint
+          properties:
+            endpoints:
+              items:
+                description: Endpoint is a high-level association between a service
+                  and an IP.
+                properties:
+                  dnsName:
+                    description: The FQDN of the DNS record.
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels stores labels defined for the Endpoint.
+                    type: object
+                  recordTTL:
+                    description: TTL for the record in seconds.
+                    format: int64
+                    type: integer
+                  recordType:
+                    description: RecordType type of record, e.g. CNAME, A, SRV, TXT
+                      etc.
+                    type: string
+                  targets:
+                    description: The targets that the DNS record points to.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          description: DNSEndpointStatus defines the observed state of DNSEndpoint
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the DNSEndpoint.
+              format: int64
+              type: integer
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: domains.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: Domain
+    listKind: DomainList
+    plural: domains
+    singular: domain
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        domain:
+          description: Domain is the DNS zone associated with the KubeFed control
+            plane
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        nameServer:
+          description: NameServer is the authoritative DNS name server for the KubeFed
+            domain
+          type: string
+      required:
+      - domain
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: ingressdnsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: IngressDNSRecord
+    listKind: IngressDNSRecordList
+    plural: ingressdnsrecords
+    singular: ingressdnsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IngressDNSRecordSpec defines the desired state of IngressDNSRecord
+          properties:
+            hosts:
+              description: Host from the IngressRule in Cluster Ingress Spec
+              items:
+                type: string
+              type: array
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for the Ingress, if omitted a default would be used
+              format: int64
+              type: integer
+          type: object
+        status:
+          description: IngressDNSRecordStatus defines the observed state of IngressDNSRecord
+          properties:
+            dns:
+              description: Array of Ingress Controller LoadBalancers
+              items:
+                description: ClusterIngressDNS defines the observed status of Ingress
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding ingress controller
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: servicednsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: ServiceDNSRecord
+    listKind: ServiceDNSRecordList
+    plural: servicednsrecords
+    singular: servicednsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "ServiceDNSRecord defines a scheme of DNS name and subdomains that
+        should be programmed with endpoint information about a Service deployed in
+        multiple Kubernetes clusters. ServiceDNSRecord is name-associated with the
+        Services it programs endpoint information for, meaning that a ServiceDNSRecord
+        expresses the intent to program DNS with information about endpoints for the
+        Kubernetes Service resources with the same name and namespace in different
+        clusters. \n For the example, given the following values: \n metadata.name:
+        test-service metadata.namespace: test-namespace spec.federationName: test-federation
+        \n the following set of DNS names will be programmed: \n Global Level: test-service.test-namespace.test-federation.svc.<federation-domain>
+        Region Level: test-service.test-namespace.test-federation.svc.(status.DNS[*].region).<federation-domain>
+        Zone Level  : test-service.test-namespace.test-federation.svc.(status.DNS[*].zone).(status.DNS[*].region).<federation-domain>
+        \n Optionally, when DNSPrefix is specified, another DNS name will be programmed
+        which would be a CNAME record pointing to DNS name at global level as below:
+        <dns-prefix>.<federation-domain> --> test-service.test-namespace.test-federation.svc.<federation-domain>"
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceDNSRecordSpec defines the desired state of ServiceDNSRecord.
+          properties:
+            allowServiceWithoutEndpoints:
+              description: AllowServiceWithoutEndpoints allows DNS records to be written
+                for Service shards without endpoints
+              type: boolean
+            dnsPrefix:
+              description: DNSPrefix when specified, an additional DNS record would
+                be created with <DNSPrefix>.<KubeFedDomain>
+              type: string
+            domainRef:
+              description: DomainRef is the name of the domain object to which the
+                corresponding federated service belongs
+              type: string
+            externalName:
+              description: ExternalName when specified, replaces the service name
+                portion of a resource record with the value of ExternalName.
+              type: string
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for this Service, if omitted a default would be used
+              format: int64
+              type: integer
+          required:
+          - domainRef
+          type: object
+        status:
+          description: ServiceDNSRecordStatus defines the observed state of ServiceDNSRecord.
+          properties:
+            dns:
+              items:
+                description: ClusterDNS defines the observed status of LoadBalancer
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding service
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  region:
+                    description: Region to which the cluster belongs
+                    type: string
+                  zones:
+                    description: Zones to which the cluster belongs
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            domain:
+              description: Domain is the DNS domain of the KubeFed control plane as
+                in Domain API
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  name: replicaschedulingpreferences.scheduling.kubefed.io
+spec:
+  group: scheduling.kubefed.io
+  names:
+    kind: ReplicaSchedulingPreference
+    listKind: ReplicaSchedulingPreferenceList
+    plural: replicaschedulingpreferences
+    singular: replicaschedulingpreference
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReplicaSchedulingPreferenceSpec defines the desired state of
+            ReplicaSchedulingPreference
+          properties:
+            clusters:
+              additionalProperties:
+                description: Preferences regarding number of replicas assigned to
+                  a cluster workload object (dep, rs, ..) within a federated workload
+                  object.
+                properties:
+                  maxReplicas:
+                    description: Maximum number of replicas that should be assigned
+                      to this cluster workload object. Unbounded if no value provided
+                      (default).
+                    format: int64
+                    type: integer
+                  minReplicas:
+                    description: Minimum number of replicas that should be assigned
+                      to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                  weight:
+                    description: A number expressing the preference to put an additional
+                      replica to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                type: object
+              description: A mapping between cluster names and preferences regarding
+                a local workload object (dep, rs, .. ) in these clusters. "*" (if
+                provided) applies to all clusters if an explicit mapping is not provided.
+                If omitted, clusters without explicit preferences should not have
+                any replicas scheduled.
+              type: object
+            rebalance:
+              description: If set to true then already scheduled and running replicas
+                may be moved to other clusters in order to match current state to
+                the specified preferences. Otherwise, if set to false, up and running
+                replicas will not be moved.
+              type: boolean
+            targetKind:
+              description: TODO (@irfanurrehman); upgrade this to label selector only
+                if need be. The idea of this API is to have a a set of preferences
+                which can be used for a target FederatedDeployment or FederatedReplicaset.
+                Although the set of preferences in question can be applied to multiple
+                target objects using label selectors, but there are no clear advantages
+                of doing that as of now. To keep the implementation and usage simple,
+                matching ns/name of RSP resource to the target resource is sufficient
+                and only additional information needed in RSP resource is a target
+                kind (FederatedDeployment or FederatedReplicaset).
+              type: string
+            totalReplicas:
+              description: Total number of pods desired across federated clusters.
+                Replicas specified in the spec for target deployment template or replicaset
+                template will be discarded/overridden when scheduling preferences
+                are specified.
+              format: int32
+              type: integer
+          required:
+          - targetKind
+          - totalReplicas
+          type: object
+        status:
+          description: ReplicaSchedulingPreferenceStatus defines the observed state
+            of ReplicaSchedulingPreference
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+{{ end }}

--- a/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
       - command:
         - /hyperfed/controller-manager
+        - "--v={{ .Values.logLevel }}"
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: controller-manager

--- a/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubefed-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    kubefed-control-plane: controller-manager
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      kubefed-control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        kubefed-control-plane: controller-manager
+    spec:
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: kubefed-controller
+      containers:
+      - command:
+        - /hyperfed/controller-manager
+        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: controller-manager
+        ports:
+        - containerPort: 9090
+          name: metrics
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 3
+          timeoutSeconds: 3
+        resources:
+{{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: kubefed-admission-webhook
+  labels:
+    kubefed-admission-webhook: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kubefed-admission-webhook: "true"
+  template:
+    metadata:
+      labels:
+        kubefed-admission-webhook: "true"
+    spec:
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: kubefed-admission-webhook
+      containers:
+      - name: admission-webhook
+        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command:
+        - "/hyperfed/webhook"
+        - "--secure-port=8443"
+        - "--audit-log-path=-"
+        - "--tls-cert-file=/var/serving-cert/tls.crt"
+        - "--tls-private-key-file=/var/serving-cert/tls.key"
+        - "--v=8"
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/serving-cert
+          name: serving-cert
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+      volumes:
+      - name: serving-cert
+        secret:
+          defaultMode: 420
+          secretName: kubefed-admission-webhook-serving-cert

--- a/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
+++ b/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
@@ -1,0 +1,33 @@
+apiVersion: core.kubefed.io/v1beta1
+kind: KubeFedConfig
+metadata:
+  name: kubefed
+  namespace: {{ .Release.Namespace }}
+spec:
+  scope: {{ .Values.global.scope | default "Cluster" | quote }}
+  controllerDuration:
+    availableDelay: {{ .Values.clusterAvailableDelay | default "20s" | quote }}
+    unavailableDelay: {{ .Values.clusterUnavailableDelay | default "60s" | quote }}
+  leaderElect:
+    leaseDuration: {{ .Values.leaderElectLeaseDuration | default "15s" | quote }}
+    renewDeadline: {{ .Values.leaderElectRenewDeadline | default "10s" | quote }}
+    retryPeriod: {{ .Values.leaderElectRetryPeriod | default "5s" | quote }}
+    resourceLock: {{ .Values.leaderElectResourceLock | default "configmaps" | quote }}
+  clusterHealthCheck:
+    period: {{ .Values.clusterHealthCheckPeriod | default "10s" | quote }}
+    failureThreshold: {{ .Values.clusterHealthCheckFailureThreshold | default 3 }}
+    successThreshold: {{ .Values.clusterHealthCheckSuccessThreshold | default 1 }}
+    timeout: {{ .Values.clusterHealthCheckTimeout | default "3s" | quote }}
+  syncController:
+    adoptResources: {{ .Values.syncController.adoptResources | default "Enabled" | quote }}
+  featureGates:
+{{- if .Values.featureGates }}
+  - name: PushReconciler
+    configuration: {{ .Values.featureGates.PushReconciler | default "Enabled" | quote }}
+  - name: SchedulerPreferences
+    configuration: {{ .Values.featureGates.SchedulerPreferences | default "Enabled" | quote }}
+  - name: CrossClusterServiceDiscovery
+    configuration: {{ .Values.featureGates.CrossClusterServiceDiscovery | default "Enabled" | quote }}
+  - name: FederatedIngress
+    configuration: {{ .Values.featureGates.FederatedIngress | default "Enabled" | quote }}
+{{- end }}

--- a/kubefed/charts/controllermanager/templates/rolebindings.yaml
+++ b/kubefed/charts/controllermanager/templates/rolebindings.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubefed-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubefed-role
+subjects:
+- kind: ServiceAccount
+  name: kubefed-controller
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubefed-config-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubefed-config-role
+subjects:
+- kind: ServiceAccount
+  name: kubefed-controller
+  namespace: {{ .Release.Namespace }}
+---
+# Grant admission webhook access to core.kubefed.io in the KubeFed system
+# namespace only, regardless of kubefed deployment scope.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubefed-admission-webhook-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubefed-admission-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: kubefed-admission-webhook
+  namespace: {{ .Release.Namespace }}
+---
+# Allow the admission webhook to read the config for terminating
+# authentication.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+# TODO(font) For namespace scoped deployments, create a unique resource name in
+# the kube-system namespace using the namespace. This is needed because
+# admission-webhooks do not currently support the ability to have
+# namespace-scoped RBAC permissions only.
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: kubefed-admission-webhook:{{ .Release.Namespace }}:apiextension-viewer
+{{ else }}
+  name: kubefed-admission-webhook:apiextension-viewer
+{{ end }}
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: kubefed-admission-webhook
+  namespace: {{ .Release.Namespace }}

--- a/kubefed/charts/controllermanager/templates/roles.yaml
+++ b/kubefed/charts/controllermanager/templates/roles.yaml
@@ -1,0 +1,106 @@
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+  name: kubefed-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+  name: kubefed-config-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Only need access to these core namespaced resources in the KubeFed system
+# namespace regardless of kubefed deployment scope.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+  name: kubefed-admission-webhook-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - federatedtypeconfigs
+  - kubefedclusters
+  - kubefedconfigs
+  verbs:
+  - get
+  - watch
+  - list

--- a/kubefed/charts/controllermanager/templates/service.yaml
+++ b/kubefed/charts/controllermanager/templates/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubefed-admission-webhook
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    kubefed-admission-webhook: "true"
+  ports:
+  - port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubefed-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/port: "9090"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    kubefed-control-plane: "controller-manager"
+  ports:
+  - name: metrics
+    port: 9090
+    targetPort: metrics

--- a/kubefed/charts/controllermanager/templates/serviceaccounts.yaml
+++ b/kubefed/charts/controllermanager/templates/serviceaccounts.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubefed-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: kubefed-admission-webhook

--- a/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -1,0 +1,139 @@
+{{- $ca := genCA "kubefed-admission-webhook-ca" 3650 }}
+{{- $cn := printf "%s-admission-webhook" .Release.Name }}
+{{- $altName1 := printf "kubefed-admission-webhook.%s" .Release.Namespace }}
+{{- $altName2 := printf "kubefed-admission-webhook.%s.svc" .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+# For namespace scoped deployments, create a unique cluster-scoped resource
+# using the namespace.
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: validations.core.kubefed.io-{{ .Release.Namespace }}
+{{ else }}
+  name: validations.core.kubefed.io
+{{ end }}
+webhooks:
+- name: federatedtypeconfigs.core.kubefed.io
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: kubefed-admission-webhook
+      path: /apis/validation.core.kubefed.io/v1beta1/federatedtypeconfigs
+    caBundle: {{ b64enc $ca.Cert | quote }}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - core.kubefed.io
+    apiVersions:
+    - v1beta1
+    resources:
+    - federatedtypeconfigs
+    - federatedtypeconfigs/status
+  failurePolicy: Fail
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+# For namespace scoped deployments: filter admission webhook requests for
+# resources whose namespace matches the default namespace label applied by helm
+# upon creating the namespace. User must set this label manually if namespace
+# is created prior to installing chart with helm.
+# TODO(font): Use custom namespace label once helm adds support for it. See
+# https://github.com/helm/helm/issues/4178 for more details.
+  namespaceSelector:
+    matchLabels:
+      name: {{ .Release.Namespace }}
+{{ end }}
+- name: kubefedclusters.core.kubefed.io
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: kubefed-admission-webhook
+      path: /apis/validation.core.kubefed.io/v1beta1/kubefedclusters
+    caBundle: {{ b64enc $ca.Cert | quote }}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - core.kubefed.io
+    apiVersions:
+    - v1beta1
+    resources:
+    - kubefedclusters
+    - kubefedclusters/status
+  failurePolicy: Fail
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+# See comment above.
+  namespaceSelector:
+    matchLabels:
+      name: {{ .Release.Namespace }}
+{{ end }}
+- name: kubefedconfigs.core.kubefed.io
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: kubefed-admission-webhook
+      path: /apis/validation.core.kubefed.io/v1beta1/kubefedconfigs
+    caBundle: {{ b64enc $ca.Cert | quote }}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - core.kubefed.io
+    apiVersions:
+    - v1beta1
+    resources:
+    - kubefedconfigs
+  failurePolicy: Fail
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+# See comment above.
+  namespaceSelector:
+    matchLabels:
+      name: {{ .Release.Namespace }}
+{{ end }}
+---
+# The same comments for ValidatingWebhookConfiguration apply here to
+# MutatingWebhookConfiguration.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: mutation.core.kubefed.io-{{ .Release.Namespace }}
+{{ else }}
+  name: mutation.core.kubefed.io
+{{ end }}
+webhooks:
+- name: kubefedconfigs.core.kubefed.io
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: kubefed-admission-webhook
+      path: /apis/mutation.core.kubefed.io/v1beta1/kubefedconfigs
+    caBundle: {{ b64enc $ca.Cert | quote }}
+  rules:
+  - operations:
+    - CREATE
+    apiGroups:
+    - core.kubefed.io
+    apiVersions:
+    - v1beta1
+    resources:
+    - kubefedconfigs
+  failurePolicy: Fail
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  namespaceSelector:
+    matchLabels:
+      name: {{ .Release.Namespace }}
+{{ end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: kubefed-admission-webhook-serving-cert
+type: kubernetes.io/tls
+stringData:
+  tls.crt: {{ $cert.Cert | quote }}
+  tls.key: {{ $cert.Key | quote }}

--- a/kubefed/crds/crds.yaml
+++ b/kubefed/crds/crds.yaml
@@ -1,0 +1,1297 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedclusterroles.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedClusterRole
+    plural: federatedclusterroles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedconfigmaps.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedConfigMap
+    plural: federatedconfigmaps
+    shortNames:
+    - fcm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federateddeployments.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedDeployment
+    plural: federateddeployments
+    shortNames:
+    - fdeploy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedingresses.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedIngress
+    plural: federatedingresses
+    shortNames:
+    - fing
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedjobs.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedJob
+    plural: federatedjobs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatednamespaces.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedNamespace
+    plural: federatednamespaces
+    shortNames:
+    - fns
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedreplicasets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedReplicaSet
+    plural: federatedreplicasets
+    shortNames:
+    - frs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedsecrets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedSecret
+    plural: federatedsecrets
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedserviceaccounts.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedServiceAccount
+    plural: federatedserviceaccounts
+    shortNames:
+    - fsa
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedservices.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedService
+    plural: federatedservices
+    shortNames:
+    - fsvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1

--- a/kubefed/requirements.yaml
+++ b/kubefed/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: controllermanager
+  version: 0.0.2
+  condition: controllermanager.enabled

--- a/kubefed/templates/_helpers.tpl
+++ b/kubefed/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubefed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubefed.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubefed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kubefed/templates/crds.yaml
+++ b/kubefed/templates/crds.yaml
@@ -1,0 +1,1320 @@
+{{ if (or (or (not .Values.global.scope) (eq .Values.global.scope "Cluster")) (not (.Capabilities.APIVersions.Has "types.kubefed.io/v1beta1"))) }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedclusterroles.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedClusterRole
+    plural: federatedclusterroles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedconfigmaps.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedConfigMap
+    plural: federatedconfigmaps
+    shortNames:
+    - fcm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federateddeployments.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedDeployment
+    plural: federateddeployments
+    shortNames:
+    - fdeploy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedingresses.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedIngress
+    plural: federatedingresses
+    shortNames:
+    - fing
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedjobs.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedJob
+    plural: federatedjobs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatednamespaces.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedNamespace
+    plural: federatednamespaces
+    shortNames:
+    - fns
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedreplicasets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedReplicaSet
+    plural: federatedreplicasets
+    shortNames:
+    - frs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedsecrets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedSecret
+    plural: federatedsecrets
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedserviceaccounts.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedServiceAccount
+    plural: federatedserviceaccounts
+    shortNames:
+    - fsa
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  name: federatedservices.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedService
+    plural: federatedservices
+    shortNames:
+    - fsvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+{{ end }}

--- a/kubefed/templates/federatedtypeconfig.yaml
+++ b/kubefed/templates/federatedtypeconfig.yaml
@@ -1,0 +1,185 @@
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: clusterroles.rbac.authorization.k8s.io
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedClusterRole
+    pluralName: federatedclusterroles
+    scope: Cluster
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRole
+    pluralName: clusterroles
+    scope: Cluster
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: configmaps
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedConfigMap
+    pluralName: federatedconfigmaps
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    kind: ConfigMap
+    pluralName: configmaps
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: deployments.apps
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedDeployment
+    pluralName: federateddeployments
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    group: apps
+    kind: Deployment
+    pluralName: deployments
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: ingresses.extensions
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedIngress
+    pluralName: federatedingresses
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    group: extensions
+    kind: Ingress
+    pluralName: ingresses
+    scope: Namespaced
+    version: v1beta1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: jobs.batch
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedJob
+    pluralName: federatedjobs
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    group: batch
+    kind: Job
+    pluralName: jobs
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: namespaces
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedNamespace
+    pluralName: federatednamespaces
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    kind: Namespace
+    pluralName: namespaces
+    scope: Cluster
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: replicasets.apps
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedReplicaSet
+    pluralName: federatedreplicasets
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    group: apps
+    kind: ReplicaSet
+    pluralName: replicasets
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: secrets
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedSecret
+    pluralName: federatedsecrets
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    kind: Secret
+    pluralName: secrets
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: serviceaccounts
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedServiceAccount
+    pluralName: federatedserviceaccounts
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    kind: ServiceAccount
+    pluralName: serviceaccounts
+    scope: Namespaced
+    version: v1
+---
+apiVersion: core.kubefed.io/v1beta1
+kind: FederatedTypeConfig
+metadata:
+  name: services
+spec:
+  federatedType:
+    group: types.kubefed.io
+    kind: FederatedService
+    pluralName: federatedservices
+    scope: Namespaced
+    version: v1beta1
+  propagation: Enabled
+  targetType:
+    kind: Service
+    pluralName: services
+    scope: Namespaced
+    version: v1

--- a/kubefed/values.yaml
+++ b/kubefed/values.yaml
@@ -11,10 +11,11 @@ controllermanager:
   image: kubefed
   tag: canary
   imagePullPolicy: IfNotPresent
+  logLevel: 2
   resources:
     limits:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 500m
+      memory: 512Mi
     requests:
       cpu: 100m
       memory: 64Mi

--- a/kubefed/values.yaml
+++ b/kubefed/values.yaml
@@ -1,0 +1,48 @@
+# Default values for kubefed.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Configuration values for kubefed controllermanager deployment.
+##
+controllermanager:
+  enabled: true
+  replicaCount: 2
+  repository: quay.io/kubernetes-multicluster
+  image: kubefed
+  tag: canary
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  clusterAvailableDelay:
+  clusterUnavailableDelay:
+  leaderElectLeaseDuration:
+  leaderElectRenewDeadline:
+  leaderElectRetryPeriod:
+  clusterHealthCheckPeriod:
+  clusterHealthCheckFailureThreshold:
+  clusterHealthCheckSuccessThreshold:
+  clusterHealthCheckTimeout:
+  ## Supported options are `configmaps` and `endpoints`
+  leaderElectResourceLock:
+  syncController:
+    adoptResources:
+  ## Value of feature gates item should be either `Enabled` or `Disabled`
+  featureGates:
+    PushReconciler:
+    SchedulerPreferences:
+    CrossClusterServiceDiscovery:
+    FederatedIngress:
+
+## Configuration global values for all charts
+##
+global:
+  ## The scope of the the kubefed control plane.  Supported options
+  ## are `Cluster` (watch cluster-scoped resources and resources in
+  ## all namespaces) and `Namespaced` (only watch resources in the
+  ## kubefed system namespace). If unset, will default to `Cluster`.
+  scope: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Add a fork of the official kubefed chart to make it helm 3 compatible.


### Why?
Althought keeping it in the fork would allow use to merge upstream changes more easily, this chart hasn't changed much in the past and the fork became unmaintainable (images were built from different branches, etc)

Keeping the fork here will allow us to drop the fork and maintain the chart indefinitely, although it will require us to manually apply patches. Hopefully they fix it soon. It is reported in kubernetes-sigs/kubefed#1234
