### PR TITLE
Dex/bump postgresql chart version

### DIFF
--- a/dex/Chart.yaml
+++ b/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.6.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 icon: https://raw.githubusercontent.com/dexidp/dex/master/Documentation/logos/dex-glyph-color.png

--- a/dex/requirements.yaml
+++ b/dex/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: "3.9.1"
+  version: "8.6.4"
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Bump postgresql chart version in the dex dependencies.

### Why?
The postgresql statefulset uses `apps/v1beta2` apiversion.