### PR TITLE
enable archival in the chart

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.13.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -226,64 +226,67 @@ docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --dom
 The following table lists the configurable parameters of the chart and their default values.
 Global options overridable per service are marked with an asterisk.
 
-| Parameter                                         | Description                                           | Default               |
-|---------------------------------------------------|-------------------------------------------------------|-----------------------|
-| `nameOverride`                                    | Override name of the application                      | ``                    |
-| `fullnameOverride`                                | Override full name of the application                 | ``                    |
-| `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.7.1`               |
-| `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
-| `server.replicaCount`*                            | Server replica count                                  | `1`                   |
-| `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |
-| `server.metrics.serviceMonitor.enabled`*          | Enable Prometheus ServiceMonitor                      | `false`               |
-| `server.metrics.prometheus.timerType`*            | Prometheus timer type                                 | `histogram`           |
-| `server.metrics.statsd.hostPort`*                 | Statsd daemon host and port                           | ``                    |
-| `server.podAnnotations`*                          | Server pod annotations                                | `{}`                  |
-| `server.resources`*                               | Server CPU/Memory resource requests/limits            | `{}`                  |
-| `server.nodeSelector`*                            | Node labels for pod assignment                        | `{}`                  |
-| `server.tolerations`*                             | Toleration labels for pod assignment                  | `[]`                  |
-| `server.affinity`*                                | Affinity settings for pod assignment                  | `{}`                  |
-| `server.config.logLevel`                          | Server log level                                      | `debug,info`          |
-| `server.config.numHistoryShards`                  | Number of history shards                              | `1000`                |
-| `server.config.persistence.[store].driver`        | Connection driver                                     | `cassandra`           |
-| `server.config.persistence.[store].cassandra`     | Cassandra connection details (see `values.yaml`)      | `{}`                  |
-| `server.config.persistence.[store].sql`           | SQL connection details (see `values.yaml`)            | `{}`                  |
-| `server.[service].service.type`                   | `[service]` service type                              | `ClusterIP`           |
-| `server.[service].service.port`                   | `[service]` service port                              | `7933/7934/7935/7939` |
-| `server.[service].metrics.annotations.enabled`    | Annotate `[service]` pods with Prometheus annotations | ``                    |
-| `server.[service].metrics.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for `[service]`      | ``                    |
-| `server.[service].metrics.prometheus.timerType`   | `[service]` Prometheus timer type                     | ``                    |
-| `server.[service].metrics.statsd.hostPort`        | `[service]` Statsd daemon host and port               | ``                    |
-| `server.[service].podAnnotations`                 | `[service]` pod annotations                           | `{}`                  |
-| `server.[service].resources`                      | `[service]` CPU/Memory resource requests/limits       | `{}`                  |
-| `server.[service].nodeSelector`                   | `[service]` Node labels for pod assignment            | `{}`                  |
-| `server.[service].tolerations`                    | `[service]` Toleration labels for pod assignment      | `[]`                  |
-| `server.[service].affinity`                       | `[service]` Affinity settings for pod assignment      | `{}`                  |
-| `server.frontend.service.nodePort`                | frontend service nodePort, if service type is NodePort| ``                    |
-| `web.enabled`                                     | Enable WebUI service                                  | `true`                |
-| `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
-| `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
-| `web.image.tag`                                   | WebUI image tag                                       | `3.3.2`               |
-| `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
-| `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
-| `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |
-| `web.service.port`                                | WebUI service port                                    | `80`                  |
-| `web.service.nodePort`                            | WebUI service nodePort, if service type is NodePort   | ``                    |
-| `web.ingress.enabled`                             | Enable WebUI Ingress                                  | `false`               |
-| `web.ingress.annotations`                         | WebUI Ingress annotations                             | `{}`                  |
-| `web.ingress.hosts`                               | WebUI Ingress hosts                                   | `/`                   |
-| `web.ingress.tls`                                 | WebUI Ingress tls config                              | `[]`                  |
-| `web.resources`                                   | WebUI CPU/Memory resource requests/limits             | `{}`                  |
-| `web.nodeSelector`                                | Node labels for pod assignment                        | `{}`                  |
-| `web.tolerations`                                 | Toleration labels for pod assignment                  | `[]`                  |
-| `web.affinity`                                    | Affinity settings for pod assignment                  | `{}`                  |
-| `schema.setup.enabled`                            | Create database or keyspace                           | `true`                |
-| `schema.setup.backoffLimit`                       | Create database job back off limit                    | `100`                 |
-| `schema.update.enabled`                           | Update schema                                         | `true`                |
-| `schema.update.backoffLimit`                      | Update schema job back off limit                      | `100`                 |
-| `cassandra.enabled`                               | Install Cassandra cluster                             | `true`                |
-| `cassandra.config.cluster_size`                   | Cassandra cluster node number                         | `1`                   |
-| `mysql.enabled`                                   | Install MySQL                                         | `false`               |
+| Parameter                                         | Description                                           | Default                                           |
+|---------------------------------------------------|-------------------------------------------------------|---------------------------------------------------|
+| `nameOverride`                                    | Override name of the application                      | ``                                                |
+| `fullnameOverride`                                | Override full name of the application                 | ``                                                |
+| `server.image.repository`                         | Server image repository                               | `ubercadence/server`                              |
+| `server.image.tag`                                | Server image tag                                      | `0.7.1`                                           |
+| `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`                                    |
+| `server.replicaCount`*                            | Server replica count                                  | `1`                                               |
+| `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`                                           |
+| `server.metrics.serviceMonitor.enabled`*          | Enable Prometheus ServiceMonitor                      | `false`                                           |
+| `server.metrics.prometheus.timerType`*            | Prometheus timer type                                 | `histogram`                                       |
+| `server.metrics.statsd.hostPort`*                 | Statsd daemon host and port                           | ``                                                |
+| `server.podAnnotations`*                          | Server pod annotations                                | `{}`                                              |
+| `server.resources`*                               | Server CPU/Memory resource requests/limits            | `{}`                                              |
+| `server.nodeSelector`*                            | Node labels for pod assignment                        | `{}`                                              |
+| `server.tolerations`*                             | Toleration labels for pod assignment                  | `[]`                                              |
+| `server.affinity`*                                | Affinity settings for pod assignment                  | `{}`                                              |
+| `server.config.logLevel`                          | Server log level                                      | `debug,info`                                      |
+| `server.config.numHistoryShards`                  | Number of history shards                              | `1000`                                            |
+| `server.config.persistence.[store].driver`        | Connection driver                                     | `cassandra`                                       |
+| `server.config.persistence.[store].cassandra`     | Cassandra connection details (see `values.yaml`)      | `{}`                                              |
+| `server.config.persistence.[store].sql`           | SQL connection details (see `values.yaml`)            | `{}`                                              |
+| `server.[service].service.type`                   | `[service]` service type                              | `ClusterIP`                                       |
+| `server.[service].service.port`                   | `[service]` service port                              | `7933/7934/7935/7939`                             |
+| `server.[service].metrics.annotations.enabled`    | Annotate `[service]` pods with Prometheus annotations | ``                                                |
+| `server.[service].metrics.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for `[service]`      | ``                                                |
+| `server.[service].metrics.prometheus.timerType`   | `[service]` Prometheus timer type                     | ``                                                |
+| `server.[service].metrics.statsd.hostPort`        | `[service]` Statsd daemon host and port               | ``                                                |
+| `server.[service].podAnnotations`                 | `[service]` pod annotations                           | `{}`                                              |
+| `server.[service].resources`                      | `[service]` CPU/Memory resource requests/limits       | `{}`                                              |
+| `server.[service].nodeSelector`                   | `[service]` Node labels for pod assignment            | `{}`                                              |
+| `server.[service].tolerations`                    | `[service]` Toleration labels for pod assignment      | `[]`                                              |
+| `server.[service].affinity`                       | `[service]` Affinity settings for pod assignment      | `{}`                                              |
+| `server.frontend.service.nodePort`                | frontend service nodePort, if service type is NodePort| ``                                                |
+| `web.enabled`                                     | Enable WebUI service                                  | `true`                                            |
+| `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                                               |
+| `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`                                 |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.3.2`                                           |
+| `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`                                    |
+| `web.service.annotations`                         | WebUI service annotations                             | `{}`                                              |
+| `web.service.type`                                | WebUI service type                                    | `ClusterIP`                                       |
+| `web.service.port`                                | WebUI service port                                    | `80`                                              |
+| `web.service.nodePort`                            | WebUI service nodePort, if service type is NodePort   | ``                                                |
+| `web.ingress.enabled`                             | Enable WebUI Ingress                                  | `false`                                           |
+| `web.ingress.annotations`                         | WebUI Ingress annotations                             | `{}`                                              |
+| `web.ingress.hosts`                               | WebUI Ingress hosts                                   | `/`                                               |
+| `web.ingress.tls`                                 | WebUI Ingress tls config                              | `[]`                                              |
+| `web.resources`                                   | WebUI CPU/Memory resource requests/limits             | `{}`                                              |
+| `web.nodeSelector`                                | Node labels for pod assignment                        | `{}`                                              |
+| `web.tolerations`                                 | Toleration labels for pod assignment                  | `[]`                                              |
+| `web.affinity`                                    | Affinity settings for pod assignment                  | `{}`                                              |
+| `schema.setup.enabled`                            | Create database or keyspace                           | `true`                                            |
+| `schema.setup.backoffLimit`                       | Create database job back off limit                    | `100`                                             |
+| `schema.update.enabled`                           | Update schema                                         | `true`                                            |
+| `schema.update.backoffLimit`                      | Update schema job back off limit                      | `100`                                             |
+| `cassandra.enabled`                               | Install Cassandra cluster                             | `true`                                            |
+| `cassandra.config.cluster_size`                   | Cassandra cluster node number                         | `1`                                               |
+| `mysql.enabled`                                   | Install MySQL                                         | `false`                                           |
+| `archival.provider`                               | Archival provider                                     | `filestore`                                       |
+| `archival.historyURI`                             | History workflow archival URI                         | `file:///tmp/cadence_archival/development`        |
+| `archival.visibilityURI`                          | Visibility workflow archival URI                      | `file:///tmp/cadence_vis_archival/development`    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -157,7 +157,41 @@ data:
       toDC: ""
 
     archival:
-      status: "disabled"
+      history:
+        status: "enabled"
+        enableRead: true
+        provider:
+        {{- if eq .Values.archival.provider "filestore" }}
+          filestore:
+            fileMode: "0666"
+            dirMode: "0766"
+        {{- end }}
+        {{- if eq .Values.archival.provider "s3store" }}
+          s3store:
+            region: {{ .Values.archival.region | default "ap-south-1" | quote }}
+        {{- end }}
+      visibility:
+        status: "enabled"
+        enableRead: true
+        provider:
+        {{- if eq .Values.archival.provider "filestore" }}
+          filestore:
+            fileMode: "0666"
+            dirMode: "0766"
+        {{- end }}
+        {{- if eq .Values.archival.provider "s3store" }}
+          s3store:
+            region: {{ .Values.archival.region | default "ap-south-1" | quote }}
+        {{- end }}
+
+    domainDefaults:
+      archival:
+        history:
+          status: "disabled"
+          URI: {{ .Values.archival.historyURI | quote }}
+        visibility:
+          status: "disabled"
+          URI: {{ .Values.archival.visibilityURI | quote }}
 
     publicClient:
       hostPort: "{{ include "cadence.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -269,3 +269,8 @@ mysql:
   initializationFiles:
     user.sql: |-
       GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';
+
+archival:
+  provider: filestore
+  historyURI: "file:///tmp/cadence_archival/development"
+  visibilityURI: "file:///tmp/cadence_vis_archival/development"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
enable archival feature in the chart


### Why?
the current chart set the archival feature as disabled globally, so that we cannot enable the archival for each domain


### Additional context


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

