### PR TITLE
[thanos] Default Backend config in ingress

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.23
+version: 0.3.24
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -167,6 +167,7 @@ These setting applicable to nearly all components.
 | $component.grpc.service.annotations | Service definition for grpc service | {} |
 | $component.grpc.service.matchLabels | Pod label selector to match grpc service on. | `{}` |
 | $component.grpc.ingress.enabled | Set up ingress for the grpc service | false |
+| $component.grpc.ingress.defaultBackend | Set up default backend for ingress | false |
 | $component.grpc.ingress.annotations | Add annotations to ingress | {} |
 | $component.grpc.ingress.labels | Add labels to ingress | {} |
 | $component.grpc.ingress.path | Ingress path | "/" |
@@ -175,7 +176,8 @@ These setting applicable to nearly all components.
 | $component.http.port | http listen port number | 10902 |
 | $component.http.service.annotations | Service definition for http service | {} |
 | $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
-| $component.http.ingress.enabled | Set up ingress for the http service | false |
+| $component.http.ingress.enabled | Set up default backend for ingress | false |
+| $component.http.ingress.defaultBackend | Set up http service | false |
 | $component.http.ingress.annotations | Add annotations to ingress | {} |
 | $component.http.ingress.labels | Add labels to ingress | {} |
 | $component.http.ingress.path | Ingress path | "/" |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -176,8 +176,8 @@ These setting applicable to nearly all components.
 | $component.http.port | http listen port number | 10902 |
 | $component.http.service.annotations | Service definition for http service | {} |
 | $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
-| $component.http.ingress.enabled | Set up default backend for ingress | false | 
-| $component.http.ingress.defaultBackend | Set up http service | false |
+| $component.http.ingress.enabled | Set up ingress for the http service | false |
+| $component.http.ingress.defaultBackend | Set up default backend for ingress | false |
 | $component.http.ingress.annotations | Add annotations to ingress | {} |
 | $component.http.ingress.labels | Add labels to ingress | {} |
 | $component.http.ingress.path | Ingress path | "/" |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -176,7 +176,7 @@ These setting applicable to nearly all components.
 | $component.http.port | http listen port number | 10902 |
 | $component.http.service.annotations | Service definition for http service | {} |
 | $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
-| $component.http.ingress.enabled | Set up default backend for ingress | false |
+| $component.http.ingress.enabled | Set up default backend for ingress | false | 
 | $component.http.ingress.defaultBackend | Set up http service | false |
 | $component.http.ingress.annotations | Add annotations to ingress | {} |
 | $component.http.ingress.labels | Add labels to ingress | {} |

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.bucket.http.ingress.labels | indent 4 }}
   {{- end }}
 spec:
-  if {{ .Values.bucket.http.ingress.defaultBackend }}
+  {{ if .Values.bucket.http.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
     servicePort: {{ $.Values.bucket.http.port }}

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml .Values.bucket.http.ingress.labels | indent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.bucket.http.ingress.defaultBackend }}
+  {{- if .Values.bucket.http.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
     servicePort: {{ $.Values.bucket.http.port }}

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -17,6 +17,11 @@ metadata:
 {{ toYaml .Values.bucket.http.ingress.labels | indent 4 }}
   {{- end }}
 spec:
+  if {{ .Values.bucket.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
+    servicePort: {{ $.Values.bucket.http.port }}
+  {{- end }}
   {{- if .Values.bucket.http.ingress.tls }}
   tls:
     {{- range .Values.bucket.http.ingress.tls }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -18,7 +18,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  if {{ .Values.query.http.ingress.defaultBackend }}
+  {{- if .Values.query.http.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
     servicePort: {{ $.Values.query.http.port }}
@@ -67,7 +67,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  if {{ .Values.query.grpc.ingress.defaultBackend }}
+  {{- if .Values.query.grpc.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
     servicePort: {{ $.Values.query.grpc.port }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -18,6 +18,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  if {{ .Values.query.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
+    servicePort: {{ $.Values.query.http.port }}
+  {{- end }}
   {{- if .Values.query.http.ingress.tls }}
   tls:
     {{- range .Values.query.http.ingress.tls }}
@@ -62,6 +67,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  if {{ .Values.query.grpc.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
+    servicePort: {{ $.Values.query.grpc.port }}
+  {{- end }}
   {{- if .Values.query.grpc.ingress.tls }}
   tls:
     {{- range .Values.query.grpc.ingress.tls }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  if {{ .Values.sidecar.http.ingress.defaultBackend }}
+  {{- if .Values.sidecar.http.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-http
     servicePort: {{ $.Values.sidecar.http.port }}
@@ -67,7 +67,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  if {{ .Values.sidecar.grpc.ingress.defaultBackend }}
+  {{- if .Values.sidecar.grpc.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
     servicePort: {{ $.Values.sidecar.grpc.port }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -18,6 +18,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  if {{ .Values.sidecar.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-http
+    servicePort: {{ $.Values.sidecar.http.port }}
+  {{- end }}
   {{- if .Values.sidecar.http.ingress.tls }}
   tls:
     {{- range .Values.sidecar.http.ingress.tls }}
@@ -62,6 +67,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  if {{ .Values.sidecar.grpc.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
+    servicePort: {{ $.Values.sidecar.grpc.port }}
+  {{- end }}
   {{- if .Values.sidecar.grpc.ingress.tls }}
   tls:
     {{- range .Values.sidecar.grpc.ingress.tls }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -17,6 +17,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  if {{ .Values.store.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
+    servicePort: {{ $.Values.store.http.port }}
+  {{- end }}
   {{- if .Values.store.http.ingress.tls }}
   tls:
     {{- range .Values.store.http.ingress.tls }}
@@ -60,6 +65,11 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  if {{ .Values.store.grpc.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
+    servicePort: {{ $.Values.store.grpc.port }}
+  {{- end }}
   {{- if .Values.store.grpc.ingress.tls }}
   tls:
     {{- range .Values.store.grpc.ingress.tls }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  if {{ .Values.store.http.ingress.defaultBackend }}
+  {{- if .Values.store.http.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
     servicePort: {{ $.Values.store.http.port }}
@@ -65,7 +65,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  if {{ .Values.store.grpc.ingress.defaultBackend }}
+  {{- if .Values.store.grpc.ingress.defaultBackend }}
   backend:
     serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
     servicePort: {{ $.Values.store.grpc.port }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -97,6 +97,8 @@ store:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -125,6 +127,8 @@ store:
     # Set up ingress for the http service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -264,6 +268,8 @@ query:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -293,6 +299,8 @@ query:
     # Set up ingress for the http service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
         # kubernetes.io/tls-acme: "true"
@@ -506,6 +514,8 @@ bucket:
     # Set up ingress for the http service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -686,6 +696,8 @@ rule:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -715,6 +727,8 @@ rule:
     # Set up ingress for the http service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -816,6 +830,8 @@ sidecar:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -842,6 +858,8 @@ sidecar:
     # Set up ingress for the http service
     ingress:
       enabled: false
+      # Set default backend for ingress
+      defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Issue # 1111 - https://github.com/banzaicloud/banzai-charts/issues/1111
| License         | Apache 2.0


### What's in this PR?
This PR will enable a feature to configure default Backend for Ingress objects.

This will be useful especially in Google Kubernetes Engine, as GKE Ingress is using kube-system's default-http-backend service as a default backend for Load Balancer if not specified, and hence becoming difficult to manage the ingress the way we want.

### Why?
NIL

### Additional context
NIL

### Checklist

- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x ] User guide and development docs updated (if needed)
- [ x] Related Helm chart(s) updated (if needed)
