### PR TITLE
[thanos] Turn autodownsampling on by default

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.24
+version: 0.3.25
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -235,7 +235,7 @@ timePartioning:
 | query.logLevel | Log level | info |
 | query.logFormat | Log format to use. Possible options: logfmt or json. | logfmt |
 | query.replicaLabels | Labels to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter. | [] |
-| query.autoDownsampling | Enable --query.auto-downsampling option for query. | false |
+| query.autoDownsampling | Enable --query.auto-downsampling option for query. | true |
 | query.webRoutePrefix |Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus. | "" |
 | query.webExternalPrefix |Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path | "" |
 | query.webPrefixHeader | Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path | "" |

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -186,7 +186,7 @@ query:
   # - prometheus_replica
   #
   # Enable --query.auto-downsampling option for query.
-  autoDownsampling: false
+  autoDownsampling: true
   # Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path.
   # This option is analogous to --web.route-prefix of Promethus.
   webRoutePrefix: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Turns autodownsampling on by default.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Without this, a default installation of Thanos won't completely work as Thanos query will try to always query for raw data, whereas compression kicks in after thirty days. In practice, this means Thanos will only return thirty days of metrics, at least when queried from Grafana

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
I would like to discuss here the historical reasons for setting autodownsampling to false by default. This PR is done with my understanding of Thanos and how it works with other services such as Grafana, but I could be missing something.
