### PR TITLE
Add support for kubelet discovery service

### DIFF
--- a/prometheus-operator-standalone/Chart.yaml
+++ b/prometheus-operator-standalone/Chart.yaml
@@ -1,12 +1,11 @@
 apiVersion: v1
-description: Stripped down version of prometheus-operator to only provision the operator and nothing else
-icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
-engine: gotpl
-name: prometheus-operator-standalone
-version: 9.2.0
 appVersion: 0.40.0
-tillerVersion: ">=2.12.0"
+description: Stripped down version of prometheus-operator to only provision the operator
+  and nothing else
 home: https://github.com/coreos/prometheus-operator
+icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 keywords:
 - operator
 - prometheus
+name: prometheus-operator-standalone
+version: 9.2.1

--- a/prometheus-operator-standalone/templates/deployment.yaml
+++ b/prometheus-operator-standalone/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ semverCompare ">= 1.16.0-0" $kubeTargetVersion | ternary .Values.prometheusOperator.configmapReloadImage.tag .Values.prometheusOperator.configmapReloadImage.tagFallback }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}
+          {{- if .Values.prometheusOperator.kubeletService }}
+            - --kubelet-service={{ .Values.prometheusOperator.kubeletService.namespace }}/{{ .Values.prometheusOperator.kubeletService.serviceName }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/prometheus-operator-standalone/values.yaml
+++ b/prometheus-operator-standalone/values.yaml
@@ -45,6 +45,11 @@ prometheusOperator:
     # additional:
     # - kube-system
 
+  kubeletService: {}
+    # Namespace and service in which to maintain the kubelet service
+    # namespace:
+    # serviceName:
+
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
   denyNamespaces: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://banzaicloud.atlassian.net/browse/BY-52
| License         | Apache 2.0


### What's in this PR?

Allow support for kubelet discovery service thus we can get rid of the pause containers in BY.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
