### PR TITLE
[thanos] Fixed bugs in thanos rules

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.24
+version: 0.3.25
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
         - "--objstore.config-file=/etc/config/object-store.yaml"
         - "--rule-file=/etc/rules/*.yaml"
         {{- range $key, $val := .Values.rule.ruleLabels }}
-        - "--label={{ $key }}={{ $val | quote }}"
+        - '--label={{ $key }}={{ $val | quote }}'
         {{- end }}
         {{- if .Values.rule.resendDelay }}
         - "--resend-delay={{ .Values.rule.resendDelay }}"
@@ -129,7 +129,7 @@ spec:
           {{- end }}
       - name: rule-volume
         configMap:
-          {{- if empty .Values.rule.ruleOverrideName -}}
+          {{- if empty .Values.rule.ruleOverrideName }}
           name: {{ include "thanos.fullname" . }}-rules
           {{- else }}
           name: {{ .Values.rule.ruleOverrideName }}

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
         - "--web.prefix-header={{ .Values.rule.webPrefixHeader }}"
         {{- end }}
         {{- if .Values.rule.queryDNSDiscovery }}
-        - "--query=dnssrv+_grpc._tcp.{{ include "thanos.componentname" (list $ "query") }}-http.{{ .Release.Namespace }}.svc.cluster.local"
+        - "--query=dnssrv+_grpc._tcp.{{ include "thanos.componentname" (list $ "query") }}-grpc.{{ .Release.Namespace }}.svc.cluster.local"
         {{- end  }}
         {{- range .Values.rule.alertmanagers }}
         - "--alertmanagers.url={{ . }}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
There are two issues
- in the rule labels since we are using the `quote` function to add quotes then using single quotes for the definition. Without it was causing the error `YAML parse error on thanos/templates/rule-statefulset.yaml: error converting YAML to JSON: yaml: line 44: did not find expected key`
- the config volume for rules had issues with related to field spacing so the output when the `ruleNameOverride` is empty was `configMap:name:` with missing newline and with the fix it is 
```
configMap:
  name: ...
```
- the query dns discovery uses the protocol grpc but the service url was using http instead of grpc.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
