### PR TITLE
Allow injecting init containers to the store component

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.24
+version: 0.3.25
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -206,6 +206,7 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | store.livenessProbe  | Set up liveness probe for store available for Thanos v0.8.0+) |  {} |
 | store.readinessProbe  | Set up readinessProbe for store (available for Thanos v0.8.0+) | {}  |
 | timePartioning   |  list of min/max time for store partitions. See more details below. Setting this will create mutlipale thanos store deployments based on the number of items in the list  | [{min: "", max: ""}] |
+| initContainers   |  InitContainers allows injecting specialized containers that run before app containers. This is meant to pre-configure and tune mounted volume permissions.  | [] |
 
 ### Store time partions
 Thanos store supports partition based on time.

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -46,6 +46,10 @@ spec:
         prometheus.io/port: "{{ $root.Values.store.http.port }}"
       {{- end }}
     spec:
+      {{- if $root.Values.store.initContainers }}
+      initContainers:
+{{ toYaml $root.Values.store.initContainers | indent 6 }}
+      {{- end }}
       containers:
       - name: thanos-store
         image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -176,6 +176,9 @@ store:
   timePartioning:
     - min: ""
       max: ""
+  
+  # InitContainers allows injecting specialized containers that run before app containers. This is meant to pre-configure and tune mounted volume permissions.
+  initContainers: []
 
 query:
   enabled: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add the ability to inject init containers to the sidecar component to be able to configure volumes before the application starts.


### Why?
Need the ability to configure volumes before the application starts.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
