### PR TITLE
Include connection attributes in cadence migration jobs

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.11.0
+version: 0.11.1
 appVersion: 0.13.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/_helpers.tpl
+++ b/cadence/templates/_helpers.tpl
@@ -277,3 +277,17 @@ MySQL host.
 {{- define "mysql.host" -}}
 {{- printf "%s.%s.svc.cluster.local" (include "call-nested" (list . "mysql" "mysql.fullname")) .Release.Namespace -}}
 {{- end -}}
+
+{{/*
+Format a string map as a query string.
+*/}}
+{{- define "to-query" }}
+{{- trimSuffix "&" (include "_to-query" .)  }}
+{{- end }}
+
+{{/*
+Format a string map as a query string.
+*/}}
+{{- define "_to-query" }}
+{{- range $key, $value := . -}}{{ $key }}={{ $value }}&{{- end -}}
+{{- end }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -99,6 +99,10 @@ spec:
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
             {{- end }}
         {{- end }}
         {{- else }}
@@ -141,6 +145,10 @@ spec:
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
             {{- end }}
         {{- end }}
 
@@ -249,6 +257,10 @@ spec:
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
             {{- end }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Add SQL connection attributes to sql migration jobs.


### Why?
Looks like the migration tool now needs it.
