### PR TITLE
[thanos] Fix PDB : only select one helm release

### DIFF
--- a/thanos/templates/query-poddisruptionbudget.yaml
+++ b/thanos/templates/query-poddisruptionbudget.yaml
@@ -21,5 +21,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thanos.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Thanos query-poddisruptionbugets selector matches all thanos queriers from all helm releases. This is an issue when using more than one thanos release. 

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes this by addin a selector on `.Release.Name`.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

