### PR TITLE
Add Ingress template for Thanos Rule component.

### DIFF
--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -1,0 +1,97 @@
+---
+{{- if and .Values.rule.enabled .Values.rule.http.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.componentname" (list $ "rule") }}-http
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: rule
+    {{- if .Values.rule.http.ingress.labels }}
+  {{ toYaml .Values.rule.http.ingress.labels | indent 4 }}
+    {{- end }}
+    {{- with .Values.rule.http.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.rule.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
+    servicePort: {{ $.Values.rule.http.port }}
+  {{- end }}
+  {{- if .Values.rule.http.ingress.tls }}
+  tls:
+    {{- range .Values.rule.http.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.rule.http.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.rule.http.ingress.path }}
+            backend:
+              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
+              servicePort: {{ $.Values.rule.http.port }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.rule.enabled .Values.rule.grpc.ingress.enabled }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: rule
+    {{- if .Values.rule.grpc.ingress.labels }}
+  {{ toYaml .Values.rule.grpc.ingress.labels | indent 4 }}
+    {{- end }}
+    {{- with .Values.rule.grpc.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.rule.grpc.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+    servicePort: {{ $.Values.rule.grpc.port }}
+  {{- end }}
+  {{- if .Values.rule.grpc.ingress.tls }}
+  tls:
+    {{- range .Values.rule.grpc.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.rule.grpc.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.rule.grpc.ingress.path }}
+            backend:
+              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+              servicePort: {{ $.Values.rule.grpc.port }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
The values.yaml file already allows configuring the ingress for the Ruler, but there was no template for that.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Add template for the Ruler ingress (http and grpc). This template was based on the query ingress template.

### Why?
The values.yaml file already allows configuring the ingress for the Ruler, but there was no template for that.
