### PR TITLE
[thanos] added ingress for thanos ruler

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.27
+version: 0.3.28
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -1,0 +1,97 @@
+---
+{{- if and .Values.rule.enabled .Values.rule.http.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.componentname" (list $ "rule") }}-http
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: rule
+    {{- if .Values.rule.http.ingress.labels }}
+  {{ toYaml .Values.rule.http.ingress.labels | indent 4 }}
+    {{- end }}
+    {{- with .Values.rule.http.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.rule.http.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
+    servicePort: {{ $.Values.rule.http.port }}
+  {{- end }}
+  {{- if .Values.rule.http.ingress.tls }}
+  tls:
+    {{- range .Values.rule.http.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.rule.http.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.rule.http.ingress.path }}
+            backend:
+              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
+              servicePort: {{ $.Values.rule.http.port }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.rule.enabled .Values.rule.grpc.ingress.enabled }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: rule
+    {{- if .Values.rule.grpc.ingress.labels }}
+  {{ toYaml .Values.rule.grpc.ingress.labels | indent 4 }}
+    {{- end }}
+    {{- with .Values.rule.grpc.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.rule.grpc.ingress.defaultBackend }}
+  backend:
+    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+    servicePort: {{ $.Values.rule.grpc.port }}
+  {{- end }}
+  {{- if .Values.rule.grpc.ingress.tls }}
+  tls:
+    {{- range .Values.rule.grpc.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.rule.grpc.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.rule.grpc.ingress.path }}
+            backend:
+              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+              servicePort: {{ $.Values.rule.grpc.port }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/banzaicloud/banzai-charts/pull/1133#issuecomment-675322133
| License         | Apache 2.0


### What's in this PR?
Added ingress for thanos ruler

### Why?
Thanos ruler has a web interface which the ingress config was present but no ingress resource defined.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- [ ] Question to reviewers - Shall we keep grpc ingress or only http would be fine?
