### PR TITLE
Fix default value of the --query argument for Thanos Rule component.

### DIFF
--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
         - "--web.prefix-header={{ .Values.rule.webPrefixHeader }}"
         {{- end }}
         {{- if .Values.rule.queryDNSDiscovery }}
-        - "--query=dnssrv+_grpc._tcp.{{ include "thanos.componentname" (list $ "query") }}-grpc.{{ .Release.Namespace }}.svc.cluster.local"
+        - "--query=dnssrv+_http._tcp.{{ include "thanos.componentname" (list $ "query") }}-http.{{ .Release.Namespace }}.svc.cluster.local"
         {{- end  }}
         {{- range .Values.rule.alertmanagers }}
         - "--alertmanagers.url={{ . }}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1030
| License         | Apache 2.0

### What's in this PR?

Fix default value of the `--query` argument for Thanos Rule component.

### Why?

See https://github.com/thanos-io/thanos/issues/2020#issuecomment-580915171
