### PR TITLE
feat(cadence): Preliminary PostgreSQL support

### DIFF
--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -76,10 +76,8 @@ spec:
           args: ['sh', '-c', 'cadence-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }}']
           {{- end }}
           {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
-          {{- if eq (include "cadence.persistence.sql.pluginName" (list $ $store)) "mysql" }}
           # args: ["cadence-sql-tool", "create", "--db", "{{ $storeConfig.sql.database }}"]
           args: ['sh', '-c', 'cadence-sql-tool create --db {{ $storeConfig.sql.database }}']
-          {{- end }}
           {{- end }}
           env:
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
@@ -251,6 +249,8 @@ spec:
           {{- if eq (include "cadence.persistence.sql.pluginName" (list $ $store)) "mysql" }}
           # args: ["cadence-sql-tool", "update-schema", "-d", "/etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
           args: ['sh', '-c', 'cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned']
+          {{- else if eq (include "cadence.persistence.sql.pluginName" (list $ $store)) "postgres" }}
+          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /etc/cadence/schema/postgres/{{ include "cadence.persistence.schema" $store }}/versioned']
           {{- end }}
           {{- end }}
           env:


### PR DESCRIPTION
Updates the chart to better support a PostgreSQL backend.

This commit does not provide feature parity with existing Cassandra or
MySQL support.  The chart has options to spin up a MySQL or Cassandra
instance and configure it for you.  This commit offers nothing
equivalent for Postgres; if you want to use a Postgres backend you must
provision and configure it yourself.

More specifically, we assume that:
- The Postgres service is up and running.
- The `cadence` user and its password are configured.
- The databases `cadence` and `cadence_visibility` exist and are
  accessible by the `cadence` user.
(This assumes default names are used.  Adjust accordingly if you're
using different names.)

As long as those requirements are met, the jobs for "schema setup" and
"schema update" should work just as they would for the MySQL backend.
The option to disable either job through the "schema.setup.enabled"
and "schema.update.enabled" values remains as before.

The changes to support this new behavior are very minor.  We simply
remove an overly strict "if mysql" check in the setup job and add an
postgres implementation for the update job.

----

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no (some behavior is changed, but it is very unlikely anyone would notice or care)
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
