### PR TITLE
Fix Thanos Bucket deployment identation for the extra args.

### DIFF
--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           {{- if .Values.bucket.label }}
           - "--label={{ .Values.bucket.label }}"
           {{- end }}
-          {{ with .Values.bucket.extraArgs }}{{ toYaml . | nindent 8 }}{{- end }}
+          {{ with .Values.bucket.extraArgs }}{{ toYaml . | nindent 10 }}{{- end }}
         ports:
           - name: http
             containerPort: {{ .Values.bucket.http.port }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?
Fix Thanos Bucket deployment identation for the extra args.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
