### PR TITLE
#1181: fix query ingress

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.29
+version: 0.3.30
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -11,12 +11,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query
-    {{- if .Values.query.http.ingress.labels }}
-  {{ toYaml .Values.query.http.ingress.labels | indent 4 }}
+  {{- if .Values.query.http.ingress.labels }}
+{{ toYaml .Values.query.http.ingress.labels | indent 4 }}
     {{- end }}
-    {{- with .Values.query.http.ingress.annotations }}
+  {{- with .Values.query.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.query.http.ingress.defaultBackend }}
   backend:
@@ -37,13 +37,13 @@ spec:
   {{- end }}
   rules:
   {{- range .Values.query.http.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $.Values.query.http.ingress.path }}
-            backend:
-              serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
-              servicePort: {{ $.Values.query.http.port }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ $.Values.query.http.ingress.path }}
+          backend:
+            serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
+            servicePort: {{ $.Values.query.http.port }}
   {{- end }}
 {{- end }}
 
@@ -60,12 +60,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query
-    {{- if .Values.query.grpc.ingress.labels }}
-  {{ toYaml .Values.query.grpc.ingress.labels | indent 4 }}
-    {{- end }}
-    {{- with .Values.query.grpc.ingress.annotations }}
+  {{- if .Values.query.grpc.ingress.labels }}
+{{ toYaml .Values.query.grpc.ingress.labels | indent 4 }}
+  {{- end }}
+  {{- with .Values.query.grpc.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.query.grpc.ingress.defaultBackend }}
   backend:
@@ -86,12 +86,12 @@ spec:
   {{- end }}
   rules:
   {{- range .Values.query.grpc.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $.Values.query.grpc.ingress.path }}
-            backend:
-              serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
-              servicePort: {{ $.Values.query.grpc.port }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ $.Values.query.grpc.ingress.path }}
+          backend:
+            serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
+            servicePort: {{ $.Values.query.grpc.port }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1181
| License         | Apache 2.0


### What's in this PR?
Pr change slitlie template for query-ingress. 


### Why?
This is how current template is rederd:
# Source: thanos/templates/query-ingress.yml
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: thanos-query-http
  labels:
    app.kubernetes.io/name: thanos
    helm.sh/chart: thanos-0.3.28
    app.kubernetes.io/instance: thanos
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 0.15.0
    app.kubernetes.io/component: query
      realm: internal
spec:
  tls:
    - hosts:
        - "query-thanos.dev-internal.example.com"
      secretName: dev-internal.example.com
  rules:
    - host: query-thanos.dev-internal.example.com
      http:
        paths:
          - path: /
            backend:
              serviceName: thanos-query-http
              servicePort: 10902

For values:
query:
  http:
    ingress:
      enabled: true
      labels: 
        realm: internal
      hosts: [query-thanos.dev-internal.example.com]
      path: "/"
      tls:
      - hosts:
        - query-thanos.dev-internal.example.com
        secretName: dev-internal.example.com


Correct should be:
# Source: thanos/templates/query-ingress.yml
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: thanos-query-http
  labels:
    app.kubernetes.io/name: thanos
    helm.sh/chart: thanos-0.3.28
    app.kubernetes.io/instance: thanos
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 0.15.0
    app.kubernetes.io/component: query
    realm: internal
spec:
  tls:
    - hosts:
        - "query-thanos.dev-internal.example.com"
      secretName: dev-internal.example.com
  rules:
  - host: query-thanos.dev-internal.example.com
    http:
      paths:
        - path: /
           backend:
            serviceName: thanos-query-http
            servicePort: 10902
### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

