### PR TITLE
prometheus-operator-standalone: pull k8s-proxy from GHCR

### DIFF
--- a/prometheus-operator-standalone/Chart.yaml
+++ b/prometheus-operator-standalone/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
 - operator
 - prometheus
 name: prometheus-operator-standalone
-version: 9.2.4
+version: 9.2.5

--- a/prometheus-operator-standalone/values.yaml
+++ b/prometheus-operator-standalone/values.yaml
@@ -195,8 +195,8 @@ prometheusOperator:
   ## K8S image
   k8sProxy:
     image:
-      repository: banzaicloud/k8s-proxy
-      tag: "0.0.3"
+      repository: ghcr.io/banzaicloud/k8s-proxy
+      tag: "0.0.4"
       pullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://banzaicloud.atlassian.net/browse/BY-374
| License         | Apache 2.0


### What's in this PR?
This PR changes the prometheus-operator-standalone chart to pull the k8s-proxy image from GHCR by default. The k8s-proxy image is now published to both dockerhub and GHCR.
