### PR TITLE
Save one ip

### DIFF
--- a/spot-termination-exporter/templates/daemonset.yaml
+++ b/spot-termination-exporter/templates/daemonset.yaml
@@ -62,6 +62,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
+      hostNetwork: {{ .Values.useHostNetwork }} 
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/spot-termination-exporter/values.yaml
+++ b/spot-termination-exporter/values.yaml
@@ -54,6 +54,7 @@ resources:
     memory: 256Mi
     cpu: 120m
 
+useHostNetwork: true
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This pull request allows users to use hostnetwork on spot-termination-exporter pods.

### Why?
It may help to save 1 "pod slot" when your provider (eg. aws) limits your number of IP / eni

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Related Helm chart(s) updated (if needed)
