### PR TITLE
Ingress API Version: allow customization of api version for ingresses

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.29
+version: 0.3.30
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -176,6 +176,7 @@ These setting applicable to nearly all components.
 | $component.http.service.annotations | Service definition for http service | {} |
 | $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
 | $component.http.ingress.enabled | Set up ingress for the http service | false |
+| $component.http.ingress.apiVersion | Set API version for ingress | extensions/v1beta1 |
 | $component.http.ingress.defaultBackend | Set up default backend for ingress | false |
 | $component.http.ingress.annotations | Add annotations to ingress | {} |
 | $component.http.ingress.labels | Add labels to ingress | {} |

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.bucket.enabled .Values.bucket.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.bucket.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -1,6 +1,6 @@
 ---
 {{- if and .Values.query.enabled .Values.query.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.query.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-http

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -1,6 +1,6 @@
 ---
 {{- if and .Values.rule.enabled .Values.rule.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.rule.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "rule") }}-http

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if and .Values.sidecar.enabled .Values.sidecar.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.sidecar.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "sidecar") }}-http

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.store.enabled .Values.store.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.sidecar.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-http

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -128,6 +128,10 @@ store:
     ingress:
       enabled: false
       # Set default backend for ingress
+
+      apiVersion: extensions/v1beta1
+      # Set API version for ingress
+
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -310,6 +314,10 @@ query:
     ingress:
       enabled: false
       # Set default backend for ingress
+
+      apiVersion: extensions/v1beta1
+      # Set API version for ingress
+
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -535,6 +543,10 @@ bucket:
     ingress:
       enabled: false
       # Set default backend for ingress
+
+      apiVersion: extensions/v1beta1
+      # Set API version for ingress
+
       defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
@@ -748,6 +760,10 @@ rule:
     ingress:
       enabled: false
       # Set default backend for ingress
+
+      apiVersion: extensions/v1beta1
+      # Set API version for ingress
+
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -879,6 +895,10 @@ sidecar:
     ingress:
       enabled: false
       # Set default backend for ingress
+
+      apiVersion: extensions/v1beta1
+      # Set API version for ingress
+
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Minor change to Thanos: API version for ingress can now be customized in the Thanos values file.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Our team needed to use `networking.k8s.io/v1beta1` for our API version in the ingress, I thought it could be helpful to allow the ingress API version to be set in the Thanos values file.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
