### PR TITLE
thanos: fix store annotations and labels templating

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.3.30
+version: 0.3.31
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/store-persistentvolumeclaim.yaml
+++ b/thanos/templates/store-persistentvolumeclaim.yaml
@@ -20,9 +20,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
-{{ with $root.Values.store.deploymentLabels }}{{ toYaml $root | indent 4 }}{{ end -}}
+{{ with $root.Values.store.deploymentLabels }}{{ toYaml . | indent 4 }}{{ end -}}
   {{- with $root.Values.store.deploymentAnnotations }}
-  annotations: {{ toYaml $root | nindent 4 }}
+  annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- toYaml $pvc.spec | nindent 2 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | note sure if an issue exists for that
| License         | Apache 2.0


### What's in this PR?

This fixes the thanos storage PVC annotations and labels to be correctly
render with the right content instead of the `$root` variable.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>


### Why?
Otherwise the deployment would fail because `$root` was outputed where the annotations and labels should have been rendered.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)