### PR TITLE
New operator version 3.7.0

### DIFF
--- a/grafana-operator/Chart.yaml
+++ b/grafana-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: grafana-operator
 description: Grafana-operator Helm chart for Kubernetes
 
-version: 0.2.6
+version: 0.2.7
 
 appVersion: master
 

--- a/grafana-operator/crds/grafana.yaml
+++ b/grafana-operator/crds/grafana.yaml
@@ -147,3 +147,78 @@ spec:
             jsonnet:
               type: object
               description: Jsonnet library configuration
+            livenessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer
+            readinessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: >-
+                    Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer

--- a/grafana-operator/templates/deployment.yaml
+++ b/grafana-operator/templates/deployment.yaml
@@ -51,10 +51,10 @@ spec:
           command:
           - grafana-operator
           args:
-          - -grafana-image={{ include "grafana-operator.grafana.baseImage" . }}
-          - -grafana-image-tag={{ .Values.grafana.image.tag }}
-          - -grafana-plugins-init-container-image={{ include "grafana-operator.pluginInit.baseImage" . }}
-          - -grafana-plugins-init-container-tag={{ .Values.grafanaPluginInit.image.tag }}
+          - --grafana-image={{ include "grafana-operator.grafana.baseImage" . }}
+          - --grafana-image-tag={{ .Values.grafana.image.tag }}
+          - --grafana-plugins-init-container-image={{ include "grafana-operator.pluginInit.baseImage" . }}
+          - --grafana-plugins-init-container-tag={{ .Values.grafanaPluginInit.image.tag }}
           {{- if (and .Values.args.scanAllNamespaces (not .Values.args.scanNamespaces)) }}
           - --scan-all=True
           {{- else if .Values.args.scanNamespaces }}

--- a/grafana-operator/templates/grafana.yaml
+++ b/grafana-operator/templates/grafana.yaml
@@ -90,6 +90,14 @@ spec:
     - matchExpressions:
         - {key: app.kubernetes.io/instance, operator: In, values: [{{ .Release.Name }}]}
   {{- end }}
+  {{- with .Values.defaultDeployment.readinessProbe }}
+  readinessProbeSpec:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.defaultDeployment.livenessProbe }}
+  livenessProbeSpec:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
 
   resources: {{- toYaml .Values.defaultDeployment.resources | nindent 4 }}
 {{- end }}

--- a/grafana-operator/values.yaml
+++ b/grafana-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   ## TODO change to original repo after release of UID fixes
   registry: quay.io
   repository: integreatly/grafana-operator
-  tag: v3.6.0
+  tag: v3.7.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -71,7 +71,7 @@ grafana:
   image:
     registry: docker.io
     repository: grafana/grafana
-    tag: 7.3.3
+    tag: 7.3.5
   deployment:
     annotations: {}
     labels: {}
@@ -240,6 +240,20 @@ defaultDeployment:
     anonymous: false
 
   resources: {}
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+
+  livenessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 30
+    failureThreshold: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
 
 
 defaultDatasouce:


### PR DESCRIPTION
New default grafana version 7.3.5
- livenessProbe support
- readinessProbe support

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1199
| License         | Apache 2.0

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
