### PR TITLE
fix(dex): change to clusterrole for crd creation

### DIFF
--- a/dex/templates/rbac.yaml
+++ b/dex/templates/rbac.yaml
@@ -13,9 +13,6 @@ rules:
 - apiGroups: ["dex.coreos.com"]
   resources: ["*"]
   verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -34,4 +31,38 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "dex.serviceAccountName" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dex.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dex.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Allows Dex to create CRD through a clusterrole


### Why?
Dex creates its own CRD when deployed, and as CRD are ClusterScoped resources, you need a clusterrole / clusterrolebinding.
Else, dex log the following message:

```
 time="2020-12-18T08:40:24Z" level=error msg="creating custom resource devicetokens.dex.coreos.com: POST https://[]:443/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions Forbidden: response from server \"{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"customresourcedefinitions.apiextensions.k8s.io is forbidden: User \\\"system:serviceaccount:infra-dex:dex\\\" cannot create resource \\\"customresourcedefinitions\\\" in API group \\\"apiextensions.k8s.io\\\" at the cluster scope\",\"reason\":\"Forbidden\",\"details\":{\"group\":\"apiextensions.k8s.io\",\"kind\":\"customresourcedefinitions\"},\"code\":403}\""
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

