### PR TITLE
Updated ApiVersion of Deployment for Zeppelin chart for compatibility with K8s 1.16^

### DIFF
--- a/zeppelin/Chart.yaml
+++ b/zeppelin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zeppelin
-version: 0.0.19
+version: 0.0.20
 description: A Helm chart for Kubernetes
 home: https://banzaicloud.com
 sources:

--- a/zeppelin/templates/deployment.yaml
+++ b/zeppelin/templates/deployment.yaml
@@ -1,4 +1,8 @@
-apiVersion: extensions/v1beta1
+{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +12,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | yes
| License         | Apache 2.0


### What's in this PR?
Added the template for Updated ApiVersion fro Deployment of Zeppelin Helm chart for supporting deployment over Kubernetes v1.16^

### Why?
Chart Deployment fails over Kubernetes version 1.16 and above

### Checklist
- [x] Related Helm chart(s) updated (if needed)
