### PR TITLE
add kubelet svc if feature is enabled

### DIFF
--- a/prometheus-operator-standalone/Chart.yaml
+++ b/prometheus-operator-standalone/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
 - operator
 - prometheus
 name: prometheus-operator-standalone
-version: 9.2.5
+version: 9.2.6

--- a/prometheus-operator-standalone/templates/kubelet-service.yaml
+++ b/prometheus-operator-standalone/templates/kubelet-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.prometheusOperator.kubeletService }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kubelet
+{{ include "prometheus-operator.labels" . | indent 4 }}
+  name: {{ .Values.prometheusOperator.kubeletService.serviceName }}
+  namespace: {{ .Values.prometheusOperator.kubeletService.namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - name: https-metrics
+    port: 10250
+    protocol: TCP
+    targetPort: 10250
+  - name: http-metrics
+    port: 10255
+    protocol: TCP
+    targetPort: 10255
+  - name: cadvisor
+    port: 4194
+    protocol: TCP
+    targetPort: 4194
+  type: ClusterIP
+{{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Creates the service resource if the feature is enabled.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

By default the prometheus operator creates this service if it doesn't exists, but having it defined in the chart allows proper cleanup during uninstall.
