### PR TITLE
[spot-termination-exporter] fix hostNetwork misplaced

### DIFF
--- a/spot-termination-exporter/templates/daemonset.yaml
+++ b/spot-termination-exporter/templates/daemonset.yaml
@@ -62,10 +62,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
-      hostNetwork: {{ .Values.useHostNetwork }} 
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      hostNetwork: {{ .Values.useHostNetwork }} 
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
This pull request fix a the place of the hostnetwork parameter.

### Why?
Fix this error : 
`Error: UPGRADE FAILED: template: spot-termination-exporter/templates/daemonset.yaml:65:29: executing "spot-termination-exporter/templates/daemonset.yaml" at <.Values.useHostNetwork>: nil pointer evaluating interface {}.useHostNetwork`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Related Helm chart(s) updated (if needed)
