### PR TITLE
dex: make the chart simply installable

### DIFF
--- a/dex/Chart.yaml
+++ b/dex/Chart.yaml
@@ -1,6 +1,6 @@
 name: dex
-version: 0.3.5
-appVersion: 0.6.0
+version: 0.4.0
+appVersion: 0.7.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 icon: https://raw.githubusercontent.com/dexidp/dex/master/Documentation/logos/dex-glyph-color.png
 apiVersion: v1

--- a/dex/values.yaml
+++ b/dex/values.yaml
@@ -10,7 +10,7 @@ imagePullPolicy: "IfNotPresent"
 replicas: 1
 
 postgresql:
-  enabled: true
+  enabled: false
   postgresqlUsername: dex
   postgresqlPassword: foo
   postgresqlDatabase: dex_db
@@ -89,20 +89,21 @@ config:
     skipApprovalScreen: false
 
   storage:
-    type: ""
+    type: "kubernetes"
     config:
-      database: ""
-      user: ""
-      password: ""
-      host: ""
-      ssl:
-        mode: ""
+      inCluster: true
+      # database: ""
+      # user: ""
+      # password: ""
+      # host: ""
+      # ssl:
+      #   mode: ""
 
   staticClients: []
 
   connectors: {}
 
-  enablePasswordDB: false
+  enablePasswordDB: true
   staticPasswords: []
 
 nodeSelector: {}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Allows to run `helm upgrade --install dex banzaicloud-stable/dex` and have a Running dex pod.
Also make the postgres db non-required by default.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)

