### PR TITLE
Upgraded Cadence server (0.14.1->)0.15.1, web (3.18.1->)3.22.2, chart (0.12.1->)0.13.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.12.1
-appVersion: 0.14.1
+version: 0.13.0
+appVersion: 0.15.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.10+
+- Cadence 0.15+
 
 
 ## Installing the Chart
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.7.1`               |
+| `server.image.tag`                                | Server image tag                                      | `0.15.1`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |
@@ -267,7 +267,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.enabled`                                     | Enable WebUI service                                  | `true`                |
 | `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
-| `web.image.tag`                                   | WebUI image tag                                       | `3.3.2`               |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.22.2`              |
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
 | `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |

--- a/cadence/migrations.md
+++ b/cadence/migrations.md
@@ -20,7 +20,7 @@ Set up environment variables:
 
 ```bash
 export CASSANDRA_HOST=docker.for.mac.host.internal
-export CASSANDRA_PORT=9042
+export CASSANDRA_DB_PORT=9042
 # Optionally:
 # export CASSANDRA_USER=
 # export CASSANDRA_PASSWORD=

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -85,7 +85,7 @@ spec:
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
-            - name: CASSANDRA_PORT
+            - name: CASSANDRA_DB_PORT
               value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
             - name: CASSANDRA_KEYSPACE
               value: {{ $storeConfig.cassandra.keyspace }}
@@ -133,7 +133,7 @@ spec:
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
-            - name: CASSANDRA_PORT
+            - name: CASSANDRA_DB_PORT
               value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
             - name: CASSANDRA_KEYSPACE
               value: {{ $storeConfig.cassandra.keyspace }}
@@ -257,7 +257,7 @@ spec:
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
             - name: CASSANDRA_HOST
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
-            - name: CASSANDRA_PORT
+            - name: CASSANDRA_DB_PORT
               value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
             - name: CASSANDRA_KEYSPACE
               value: {{ $storeConfig.cassandra.keyspace }}

--- a/cadence/values.prod.yaml
+++ b/cadence/values.prod.yaml
@@ -1,7 +1,7 @@
 server:
   podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '9090'
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
 
   config:
     persistence:
@@ -17,7 +17,7 @@ server:
           password: ""
 
         sql:
-          driver: "" # mysql
+          pluginName: "" # mysql
           host: ""
           # port: 3306
           database: cadence
@@ -36,7 +36,7 @@ server:
           password: ""
 
         sql:
-          driver: "" # mysql
+          pluginName: "" # mysql
           host: ""
           # port: 3306
           database: cadence_visibility

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.14.1
+    tag: 0.15.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -218,7 +218,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: 3.18.1
+    tag: v3.22.2
     pullPolicy: IfNotPresent
 
   tcheck:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Upgraded Cadence server (0.14.1->)0.15.1, web (3.18.1->)3.22.2, chart (0.12.1->)0.13.0.
Server is upgraded to the next minor version.
Web is upgraded to the latest stable (minor) version.
Chart version changed based on breaking changes is Cadence environment variables.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To converge towards latest stable version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using a Kind Pipeline control plane with 
1. cluster created using Cadence server 0.13.0, 
2. helm upgraded Cadence to 0.14.1, 
3. updated a node pool, deleted a cluster, created a cluster,
4. helm upgraded Cadence to 0.15.1,
5. updated a node pool, deleted a cluster, created a cluster,
6. deployed new cadence web,
7. queried workflows on Cadence web.

Notable changes:
Server: `CASSANDRA_PORT` env var changed to `CASSANDRA_DB_PORT`.
[0.14.2](https://github.com/uber/cadence/releases/tag/v0.14.2)
[0.15.0](https://github.com/uber/cadence/releases/tag/v0.15.0)
[0.15.1](https://github.com/uber/cadence/releases/tag/v0.15.1)

Web: default domain view queries all workflows (open and closed as well).
[3.19.0](https://github.com/uber/cadence-web/releases/tag/v3.19.0)
[3.19.1](https://github.com/uber/cadence-web/releases/tag/v3.19.1)
[3.19.2](https://github.com/uber/cadence-web/releases/tag/v3.19.2)
[3.19.3](https://github.com/uber/cadence-web/releases/tag/v3.19.3)
[3.20.0](https://github.com/uber/cadence-web/releases/tag/v3.20.0)
[3.21.0](https://github.com/uber/cadence-web/releases/tag/v3.21.0)
[3.21.1](https://github.com/uber/cadence-web/releases/tag/v3.21.1)
[3.21.2](https://github.com/uber/cadence-web/releases/tag/v3.21.2)
[3.22.0](https://github.com/uber/cadence-web/releases/tag/v3.22.0)
[3.22.1](https://github.com/uber/cadence-web/releases/tag/v3.22.1)
[3.22.2](https://github.com/uber/cadence-web/releases/tag/v3.22.2)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)