### PR TITLE
Fix handling of labels from custom values in Thanos charts

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/query-frontend-ingress.yml
+++ b/thanos/templates/query-frontend-ingress.yml
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query-frontend
-    {{- if .Values.queryFrontend.http.ingress.labels }}
-  {{ toYaml .Values.queryFrontend.http.ingress.labels | indent 4 }}
-    {{- end }}
+{{- if .Values.queryFrontend.http.ingress.labels }}
+{{ toYaml .Values.queryFrontend.http.ingress.labels | indent 4 }}
+{{- end }}
     {{- with .Values.queryFrontend.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -60,9 +60,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: query-frontend
-    {{- if .Values.queryFrontend.grpc.ingress.labels }}
-  {{ toYaml .Values.queryFrontend.grpc.ingress.labels | indent 4 }}
-    {{- end }}
+{{- if .Values.queryFrontend.grpc.ingress.labels }}
+{{ toYaml .Values.queryFrontend.grpc.ingress.labels | indent 4 }}
+{{- end }}
     {{- with .Values.queryFrontend.grpc.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: rule
-    {{- if .Values.rule.http.ingress.labels }}
-  {{ toYaml .Values.rule.http.ingress.labels | indent 4 }}
-    {{- end }}
+{{- if .Values.rule.http.ingress.labels }}
+{{ toYaml .Values.rule.http.ingress.labels | indent 4 }}
+{{- end }}
     {{- with .Values.rule.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -60,9 +60,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: rule
-    {{- if .Values.rule.grpc.ingress.labels }}
-  {{ toYaml .Values.rule.grpc.ingress.labels | indent 4 }}
-    {{- end }}
+{{- if .Values.rule.grpc.ingress.labels }}
+{{ toYaml .Values.rule.grpc.ingress.labels | indent 4 }}
+{{- end }}
     {{- with .Values.rule.grpc.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: sidecar
-    {{- if .Values.sidecar.http.ingress.labels }}
-  {{ toYaml .Values.sidecar.ingress.http.labels | indent 4 }}
-  {{- end }}
+{{- if .Values.sidecar.http.ingress.labels }}
+{{ toYaml .Values.sidecar.ingress.http.labels | indent 4 }}
+{{- end }}
   {{- with .Values.sidecar.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -60,9 +60,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: sidecar
-    {{- if .Values.sidecar.grpc.ingress.labels }}
-  {{ toYaml .Values.sidecar.grpc.ingress.labels | indent 4 }}
-  {{- end }}
+{{- if .Values.sidecar.grpc.ingress.labels }}
+{{ toYaml .Values.sidecar.grpc.ingress.labels | indent 4 }}
+{{- end }}
   {{- with .Values.sidecar.grpc.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
-  {{- if .Values.store.http.ingress.labels }}
-  {{ toYaml .Values.store.http.ingress.labels | indent 4 }}
-  {{- end }}
+{{- if .Values.store.http.ingress.labels }}
+{{ toYaml .Values.store.http.ingress.labels | indent 4 }}
+{{- end }}
   {{- with .Values.store.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -58,9 +58,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: store
-  {{- if .Values.store.grpc.ingress.labels }}
-  {{ toYaml .Values.store.grpc.ingress.labels | indent 4 }}
-  {{- end }}
+{{- if .Values.store.grpc.ingress.labels }}
+{{ toYaml .Values.store.grpc.ingress.labels | indent 4 }}
+{{- end }}
   {{- with .Values.store.grpc.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1223
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes how labels provided by custom values are being handled in Thanos chart templates.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Some chart templates aren't appending labels provided by custom chart values correctly. The provided labels are being appended with the incorrect indentation level causing the rendered YAML files to be invalid.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
