### PR TITLE
Updated Cadence server (0.15.1->)0.16.1, chart (0.13.0->)0.14.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.13.0
-appVersion: 0.15.1
+version: 0.14.0
+appVersion: 0.16.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.15+
+- Cadence 0.16+
 
 
 ## Installing the Chart
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.15.1`              |
+| `server.image.tag`                                | Server image tag                                      | `0.16.1`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/values.prod.yaml
+++ b/cadence/values.prod.yaml
@@ -23,6 +23,8 @@ server:
           database: cadence
           user: ""
           password: ""
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "" # cassandra or sql
@@ -42,6 +44,8 @@ server:
           database: cadence_visibility
           user: ""
           password: ""
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
 schema:
   setup: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.15.1
+    tag: 0.16.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -92,6 +92,8 @@ server:
           # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "" # cassandra or sql
@@ -122,6 +124,8 @@ server:
           # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
   frontend:
     # replicaCount: 1

--- a/cadence/values/values.mysql.yaml
+++ b/cadence/values/values.mysql.yaml
@@ -11,6 +11,8 @@ server:
           database: cadence
           user: "cadence"
           password: "cadence"
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "sql"
@@ -22,6 +24,8 @@ server:
           database: cadence_visibility
           user: "cadence"
           password: "cadence"
+          encodingType: "thriftrw" # Note: required only until 0.18.0.
+          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
 cassandra:
   enabled: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated Cadence server (0.15.1->)0.16.1, chart (0.13.0->)0.14.0.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To converge towards latest stable version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using a Kind Pipeline control plane 
1. cluster created using Cadence server 0.15.1,
2. helm upgraded Cadence to 0.16.1,
3. updated an old node pool, deleted an old cluster, created a new cluster, updated a new node pool, deleted a new cluster

Notable changes:
- **BREAKING CHANGE: This release contains a breaking change in workflow metadata. This change has been enabled since 0.14 release. If your workflow could be open for 6+ months or you upgrade to this release from 0.13 or below, please follow the [migration instruction](https://github.com/uber/cadence/blob/master/RELEASES.md#upgrade-to-016-and-above).**
- **BREAKING CHANGE: 0.16.0-0.18.0 server versions require explicit `encodingType` and `decodingTypes` values for `mysql/postgresql` persistence configuration, see the chart modifications for details.**

[0.16.0](https://github.com/uber/cadence/releases/tag/v0.16.0)
[0.16.1](https://github.com/uber/cadence/releases/tag/v0.16.1)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
