### PR TITLE
Updated Cadence server (0.17.0)->0.18.0, chart (0.15.0->)0.16.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.15.0
-appVersion: 0.17.0
+version: 0.16.0
+appVersion: 0.18.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.17.0+
+- Cadence 0.18.0+
 
 
 ## Installing the Chart
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.17.0`              |
+| `server.image.tag`                                | Server image tag                                      | `0.18.0`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/values.prod.yaml
+++ b/cadence/values.prod.yaml
@@ -23,8 +23,6 @@ server:
           database: cadence
           user: ""
           password: ""
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "" # cassandra or sql
@@ -44,8 +42,6 @@ server:
           database: cadence_visibility
           user: ""
           password: ""
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
 schema:
   setup: false

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.17.0
+    tag: 0.18.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -92,8 +92,6 @@ server:
           # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "" # cassandra or sql
@@ -124,8 +122,6 @@ server:
           # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
   frontend:
     # replicaCount: 1

--- a/cadence/values/values.mysql.yaml
+++ b/cadence/values/values.mysql.yaml
@@ -11,8 +11,6 @@ server:
           database: cadence
           user: "cadence"
           password: "cadence"
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
       visibility:
         driver: "sql"
@@ -24,8 +22,6 @@ server:
           database: cadence_visibility
           user: "cadence"
           password: "cadence"
-          encodingType: "thriftrw" # Note: required only until 0.18.0.
-          decodingTypes: ["thriftrw"] # Note: required only until 0.18.0.
 
 cassandra:
   enabled: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated Cadence server (0.17.0)->0.18.0, chart (0.15.0->)0.16.0.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To converge towards supporting the latest version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using a Kind Pipeline control plane:
1. cluster created using Cadence server 0.17.0,
2. helm upgraded Cadence to 0.18.0,
3. updated an old node pool, deleted an old cluster, created a new cluster, updated a new node pool, deleted a new cluster

Notable changes:
- Removed explicit encoding type and decoding types according to the 0.16.0 release notes as 0.18.0 supports default values for these attributes.

[0.18.0](https://github.com/uber/cadence/releases/tag/v0.18.0)

> - Allow using Kafka TLS without cert ca and key ([#3862](https://github.com/uber/cadence/pull/3862))
> EnableHostVerification started to be used for Kafka TLS, by default it’s false and which means InSecureSkipVerify is true for Kafka TLS. But previously InSecureSkipVerify is false. If you want to keep the same behavior, please update your config to set EnableHostVerification to be true. It won’t break anything if not doing so, but may be risky to not verify it. This option is basically the inverse of InSecureSkipVerify. See [http://golang.org/pkg/crypto/tls/](http://golang.org/pkg/crypto/tls/) for more info.
> 
> - Support visibility query with close status represented in string ([#3865](https://github.com/uber/cadence/pull/3865))
Advanced workflow visibility record query syntax now supports using string as workflow close status. Accepted values are: COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW and TIMED_OUT, case insensitive.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
