### PR TITLE
Upgraded Cadence server 0.18.1->0.18.2

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.16.1
-appVersion: 0.18.1
+version: 0.16.2
+appVersion: 0.18.2
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.18.1`              |
+| `server.image.tag`                                | Server image tag                                      | `0.18.2`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.18.1
+    tag: 0.18.2
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Upgraded Cadence server 0.18.1->0.18.2.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To support the latest version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using a Kind Pipeline control plane:

1. cluster created using Cadence server 0.18.1,
2. helm upgraded Cadence to 0.18.2,
3. updated an old node pool, deleted an old cluster, created a new cluster, updated a new node pool, deleted a new cluster

Changes:
[v0.18.2](https://github.com/uber/cadence/releases/tag/v0.18.2)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Reminder: release chart tag after merge.
