### PR TITLE
Increase k8sProxy container's memory limit in Prometheus operator pod

### DIFF
--- a/prometheus-operator-standalone/Chart.yaml
+++ b/prometheus-operator-standalone/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - operator
 - prometheus
 name: prometheus-operator-standalone
-version: 13.2.1
+version: 13.2.2
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/banzaicloud/banzai-charts

--- a/prometheus-operator-standalone/values.yaml
+++ b/prometheus-operator-standalone/values.yaml
@@ -199,10 +199,10 @@ prometheusOperator:
     resources:
       limits:
         cpu: 100m
-        memory: 100Mi
+        memory: 300Mi
       requests:
         cpu: 50m
-        memory: 50Mi
+        memory: 150Mi
 
   createCustomResource: true
 


### PR DESCRIPTION
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

On a cluster, the k8sProxy container keeps restarting because of OOMKill in every 2-3 minutes. The memory usage of the container is around 140-180Mi.

The proper solution would be to fix the likely memory leak, but until then this is a quick fix for the problem.

300Mi was chosen to give some headroom.

