### PR TITLE
add support for sharding the store by relabel-configs

### DIFF
--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -116,6 +116,9 @@ spec:
               source_labels: ["shard"]
               regex: {{ $index }}
         {{- end }}
+        {{- if $root.Values.store.relabel_configs }}
+        - "--selector.relabel-config-file=/var/thanos/relabel-configs/relabel-configs.yaml"
+        {{- end }}
         {{- if $root.Values.store.extraArgs }}
         {{ toYaml $root.Values.store.extraArgs | nindent 8 }}
         {{- end }}
@@ -135,6 +138,10 @@ spec:
           name: {{ $root.Values.store.certSecretName }}
           readOnly: true
         {{- end }}
+        {{- if $root.Values.store.relabel_configs  }}
+        - name: relabel-configs-volume
+          mountPath: /var/thanos/relabel-configs
+        {{ end }}
         {{- if $root.Values.store.livenessProbe }}
         livenessProbe:
         {{ toYaml $root.Values.store.livenessProbe | nindent 10 }}
@@ -169,6 +176,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ $root.Values.store.certSecretName }}
+      {{- end }}
+      {{- if $root.Values.store.relabel_configs  }}
+      - name: relabel-configs-volume
+        configMap:
+          name: {{ include "thanos.componentname" (list $ "store") }}-relabel-configs
       {{- end }}
       {{- with $root.Values.store.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}

--- a/thanos/templates/store-relabel-configmap.yaml
+++ b/thanos/templates/store-relabel-configmap.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.compact.relabel_configs  }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "thanos.componentname" (list $ "store") }}-relabel-configs
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: store
+data:
+  relabel-configs.yaml: |-
+    {{- toYaml .Values.compact.relabel_configs | nindent 5}}
+{{- end}}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -186,6 +186,10 @@ store:
     # shards:
   # InitContainers allows injecting specialized containers that run before app containers. This is meant to pre-configure and tune mounted volume permissions.
   initContainers: []
+
+  #relael-configs to use for sharding the store
+  #https://thanos.io/tip/thanos/sharding.md/#relabelling
+  relabel_configs: []
 query:
   enabled: true
   # Labels to treat as a replica indicator along which data is deduplicated.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
added support for sharding the compactor by relabel-configs


### Why?
you cant shard the compactor without it per https://thanos.io/tip/thanos/sharding.md/#relabelling

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
