### PR TITLE
thanos: added SA annotations

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.2
+version: 0.4.3
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -260,7 +260,7 @@ timePartioning:
 | query.autoscaling.targetCPUUtilizationPercentage | 	Target CPU utilization percentage to scale | 50 |
 | query.autoscaling.targetMemoryUtilizationPercentage |	Target memory utilization percentage to scale 50 |
 | query.serviceAccount | Name of the Kubernetes service account to use | "" |
-| query.serviceAccountAnnotations | Optional annotations to be added to the query ServiceAccount | {} |
+| query.serviceAccountAnnotations | Optional annotations to be added to the ServiceAccount | {} |
 | query.psp.enabled | Enable pod security policy, it also requires the `query.rbac.enabled` to be set to `true`. | false |
 | query.rbac.enabled | Enable RBAC to use the PSP | false |
 | query.livenessProbe | Set up liveness probe for query | {} |
@@ -355,7 +355,7 @@ timePartioning:
 | queryFrontend.cache.maxSizeItems | Maximum number of items in the cache. Use either this or `maxSize`. | `` |
 | queryFrontend.cache.validity | | `` |
 | queryFrontend.log.request.decision | Request Logging for logging the start and end of requests | `LogFinishCall` |
-| queryFrontend.serviceAccountAnnotations | Optional annotations to be added to the queryFrontend ServiceAccount | {} |
+| queryFrontend.serviceAccountAnnotations | Optional annotations to be added to the ServiceAccount | {} |
 
 ## Contributing
 Contributions are very welcome!

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -260,6 +260,7 @@ timePartioning:
 | query.autoscaling.targetCPUUtilizationPercentage | 	Target CPU utilization percentage to scale | 50 |
 | query.autoscaling.targetMemoryUtilizationPercentage |	Target memory utilization percentage to scale 50 |
 | query.serviceAccount | Name of the Kubernetes service account to use | "" |
+| query.serviceAccountAnnotations | Optional annotations to be added to the query ServiceAccount | {} |
 | query.psp.enabled | Enable pod security policy, it also requires the `query.rbac.enabled` to be set to `true`. | false |
 | query.rbac.enabled | Enable RBAC to use the PSP | false |
 | query.livenessProbe | Set up liveness probe for query | {} |
@@ -354,6 +355,7 @@ timePartioning:
 | queryFrontend.cache.maxSizeItems | Maximum number of items in the cache. Use either this or `maxSize`. | `` |
 | queryFrontend.cache.validity | | `` |
 | queryFrontend.log.request.decision | Request Logging for logging the start and end of requests | `LogFinishCall` |
+| queryFrontend.serviceAccountAnnotations | Optional annotations to be added to the queryFrontend ServiceAccount | {} |
 
 ## Contributing
 Contributions are very welcome!

--- a/thanos/templates/query-frontend-rbac.yaml
+++ b/thanos/templates/query-frontend-rbac.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- with .Values.queryFrontend.serviceAccountAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/templates/query-rbac.yaml
+++ b/thanos/templates/query-rbac.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- with .Values.query.serviceAccountAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "thanos.componentname" (list $ "query") }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -291,7 +291,7 @@ query:
       #    hosts:
       #      - chart-example.local
   serviceAccount: ""
-  # Optional annotations to be added to the query ServiceAccount
+  # Optional annotations to be added to the ServiceAccount
   serviceAccountAnnotations: {}
 
   psp:
@@ -600,7 +600,7 @@ queryFrontend:
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
   affinity: {}
 
-  # Optional annotations to be added to the query ServiceAccount
+  # Optional annotations to be added to the ServiceAccount
   serviceAccountAnnotations: {}
 
 compact:

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -291,6 +291,8 @@ query:
       #    hosts:
       #      - chart-example.local
   serviceAccount: ""
+  # Optional annotations to be added to the query ServiceAccount
+  serviceAccountAnnotations: {}
 
   psp:
     enabled: false
@@ -597,6 +599,9 @@ queryFrontend:
   # Pod affinity
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
   affinity: {}
+
+  # Optional annotations to be added to the query ServiceAccount
+  serviceAccountAnnotations: {}
 
 compact:
   enabled: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the ability to add custom annotations to the query and query-frontend ServiceAccounts. 


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This provides the ability to make use of [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to pass AWS permissions to the query and query-frontend pods.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
None

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
