### PR TITLE
Upgraded Cadence server 0.18.2->0.19.1, chart 0.16.2->0.17.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.16.2
-appVersion: 0.18.2
+version: 0.17.0
+appVersion: 0.19.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.18.0+
+- Cadence 0.19.0+
 
 
 ## Installing the Chart
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.18.2`              |
+| `server.image.tag`                                | Server image tag                                      | `0.19.1`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -141,19 +141,19 @@ data:
         {{- end}}
 
     clusterMetadata:
-      enableGlobalDomain: false
+      enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}` }}
       failoverVersionIncrement: 10
-      masterClusterName: "active"
-      currentClusterName: "active"
+      masterClusterName: "master"
+      currentClusterName: "master"
       clusterInformation:
-        active:
+        master:
           enabled: true
           initialFailoverVersion: 0
           rpcName: "cadence-frontend"
           rpcAddress: "127.0.0.1:7933"
 
     dcRedirectionPolicy:
-      policy: "noop"
+      policy: {{ `{{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}` }}
       toDC: ""
 
     archival:

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.18.2
+    tag: 0.19.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Upgraded Cadence server 0.18.2->0.19.1, chart 0.16.2->0.17.0.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To support the latest available server version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested using a Kind Pipeline control plane:

1. cluster created using Cadence server 0.18.2,
2. helm upgraded Cadence to 0.19.1,
3. updated an old node pool, deleted an old cluster, created a new cluster, updated a new node pool, deleted a new cluster

Changes:
[v0.19.1](https://github.com/uber/cadence/releases/tag/v0.19.1)

Static configuration features:

https://github.com/uber/cadence/commit/c7d2f10cc9f3172976b18de4b08b9579e267e9b8  Support AWS signing for ElasticSearch client
ElasticSearch is not supported at all by the chart yet.

https://github.com/uber/cadence/commit/7cbd5dc91cc9f4c59599a4d30c8cbb78ff2e8cd8  Add more options to config_template for docker image and disable archival by default
**Breaking chart behavior changes**: `cadence/templates/server-configmap.yaml.data.config_template.yaml` default values changed.
|                 Key path                  | Old default value |                         New default value                          |
| ----------------------------------------- | ----------------- | ------------------------------------------------------------------ |
| clusterMetadata.enableGlobalDomain        | `false`           | ``{{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}` }}``                  |
| clusterMetadata.masterClusterName         | `active`          | `master`                                                           |
| clusterMetadata.currentClusterName        | `active`          | `master`                                                           |
| clusterMetadata.clusterInformation.active | `...`             | ` `                                                                |
| clusterMetadata.clusterInformation.master | ` `               | `...`                                                              |
| dcRedirectionPolicy.policy                | `noop`            | ``{{ `{{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}` }}`` |

**As `v0.19.0` is not a "valid" release tag (see notes of `v0.19.1`), we are not providing any charts using it by default, thus the `0.17.0` chart version is using the `v0.19.1` server version as default.**

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Check features for possible chart modification.
- [x] Test manually.
- [x] If there are any breaking behavior changes during the test, emphasize it in the description at the changes section.
- [x] Add reviewers once previous steps are done.
- [x] Reminder: release chart tag after merge.
