### PR TITLE
Upgraded Cadence server 0.19.2->0.20.0, web 3.22.2->3.24.0, chart 0.17.1->0.18.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.17.1
-appVersion: 0.19.2
+version: 0.18.0
+appVersion: 0.20.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.19.2+
+- Cadence 0.20.0+
 
 
 ## Installing the Chart
@@ -231,7 +231,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.19.2`              |
+| `server.image.tag`                                | Server image tag                                      | `0.20.0`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -89,7 +89,7 @@ data:
         {{- if or .Values.server.metrics.statsd .Values.server.frontend.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.frontend.metrics.statsd.hostPort | quote }}
-            prefix: "cadence.frontend"
+            prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.frontend" }}` }}
         {{- end}}
 
       history:
@@ -105,7 +105,7 @@ data:
         {{- if or .Values.server.metrics.statsd .Values.server.history.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.history.metrics.statsd.hostPort | quote }}
-            prefix: "cadence.history"
+            prefix: {{ `{{ default .Env.STATSD_HISTORY_PREFIX "cadence.history" }}` }}
         {{- end}}
 
       matching:
@@ -121,7 +121,7 @@ data:
         {{- if or .Values.server.metrics.statsd .Values.server.matching.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.matching.metrics.statsd.hostPort | quote }}
-            prefix: "cadence.matching"
+            prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.matching" }}` }}
         {{- end}}
 
       worker:
@@ -137,20 +137,31 @@ data:
         {{- if or .Values.server.metrics.statsd .Values.server.worker.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.worker.metrics.statsd.hostPort | quote }}
-            prefix: "cadence.worker"
+            prefix: {{ `{{ default .Env.STATSD_WORKER_PREFIX "cadence.worker" }}` }}
         {{- end}}
 
     clusterMetadata:
       enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}` }}
       failoverVersionIncrement: 10
-      masterClusterName: "master"
-      currentClusterName: "master"
+      masterClusterName: "primary"
+    {{- if `{{ .Env.IS_NOT_PRIMARY }}` }}
+      currentClusterName: "secondary"
+    {{- else }}
+      currentClusterName: "primary"
+    {{- end }}
       clusterInformation:
-        master:
+        primary:
           enabled: true
           initialFailoverVersion: 0
           rpcName: "cadence-frontend"
-          rpcAddress: "127.0.0.1:7933"
+          rpcAddress: {{ `{{ default .Env.PRIMARY_SEEDS "cadence" }}` }}:7933
+      {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }}
+        secondary:
+            enabled: true
+            initialFailoverVersion: 2
+            rpcName: "cadence-frontend"
+            rpcAddress: {{ `{{ default .Env.SECONDARY_SEEDS "cadence-secondary" }}` }}:7933
+      {{- end }}
 
     dcRedirectionPolicy:
       policy: {{ `{{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}` }}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.19.2
+    tag: 0.20.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -218,7 +218,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: v3.22.2
+    tag: v3.24.0
     pullPolicy: IfNotPresent
 
   tcheck:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Upgraded Cadence server 0.19.2->0.20.0, chart 0.17.1->0.18.0.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To support the latest available version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested with the Pipeline method described in the chart upgrade documentation.

Changes:
[v0.20.0](https://github.com/uber/cadence/releases/tag/v0.20.0)

Static configuration changes:

https://github.com/uber/cadence/pull/3983  Fix IP address in docker template 
Chart default value change (see table below).

https://github.com/uber/cadence/pull/3993: Rename metric name SignalInfo to SignalInfoSize
`signal_info` -> `signal_info_size` metric name change

https://github.com/uber/cadence/commit/175850a28469c79c3ec43da7832d5a997c079667: Update docker for 0.20.0 release
`ubercadence/web` `v3.22.2` -> `v3.24.0`

https://github.com/uber/cadence/pull/4022: Add support for ScyllaDB
Scylla is not supported by the chart as of now.

`cadence/values.yaml`:
|   Key path    | Old default value | New default value |
| ------------- | ----------------- | ----------------- |
| web.image.tag | `"v3.22.2"`       | `"v3.24.0"`       |

`cadence/templates/server-configmap.yaml.data.config_template.yaml`:
|                       Key path                        |  Old default value   |                                  New default value                                  |
| ----------------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------- |
| clusterMetadata.clusterInformation.master.rpcAddress  | `"127.0.0.1:7933"`   | ``{{ `{{ default .Env.BIND_ON_IP "127.0.0.1" }}` }}:7933``                          |
| services.frontend.metrics.statsd.prefix               | `"cadence.frontend"` | ``{{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.frontend" }}` }}``            |
| services.matching.metrics.statsd.prefix               | `"cadence.history"`  | ``{{ `{{ default .Env.STATSD_HISTORY_PREFIX "cadence.history" }}` }}``              |
| services.matching.metrics.statsd.prefix               | `"cadence.matching"` | ``{{ `{{ default .Env.STATSD_MATCHING_PREFIX "cadence.matching" }}` }}``            |
| services.worker.metrics.statsd.prefix                 | `"cadence.worker"`   | ``{{ `{{ default .Env.STATSD_WORKER_PREFIX "cadence.worker" }}` }}``                |
| clusterMetadata.masterClusterName                     | `"master"`           | `"primary"`                                                                         |
| clusterMetadata.currentClusterName                    | `"master"`           | ``{{ if `{{ .Env.IS_NOT_PRIMARY }}` }} "secondary" {{ else }} "primary" {{ end }}`` |
| clusterMetadata.clusterInformation.master             | `... (renamed from)` | ` `                                                                                 |
| clusterMetadata.clusterInformation.primary            | ` `                  | `... (renamed to)`                                                                  |
| clusterMetadata.clusterInformation.primary.rpcAddress | `"127.0.0.1:7933"`   | ``{{ `{{ default .Env.PRIMARY_SEEDS "cadence" }}` }}:7933``                         |
| clusterMetadata.clusterInformation.secondary          | ` `                  | ``... (added with condition {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }})``          |

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Reminder: ->@pregnor tag & release when merged.
