### PR TITLE
Ingress Upgrades for k8s 1.23+

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.3
+version: 0.4.4
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -40,8 +40,11 @@ spec:
     http:
       paths:
         - path: {{ $.Values.bucket.http.ingress.path }}
+          pathType: {{ $.Values.bucket.http.ingress.pathType }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
-            servicePort: {{ $.Values.bucket.http.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "bucket") }}
+              port:
+                number: {{ $.Values.bucket.http.port }}
   {{- end }}
 {{ end }}

--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -19,8 +19,10 @@ metadata:
 spec:
   {{- if .Values.bucket.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
-    servicePort: {{ $.Values.bucket.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "bucket") }}
+      port:
+        number: {{ $.Values.bucket.http.port }}
   {{- end }}
   {{- if .Values.bucket.http.ingress.tls }}
   tls:

--- a/thanos/templates/query-frontend-ingress.yml
+++ b/thanos/templates/query-frontend-ingress.yml
@@ -1,6 +1,6 @@
 ---
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.http.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.queryFrontend.http.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
@@ -44,14 +44,16 @@ spec:
         paths:
           - path: {{ $.Values.queryFrontend.http.ingress.path }}
             backend:
-              serviceName: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
-              servicePort: {{ $.Values.queryFrontend.http.port }}
+              service:
+                name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
+                port:
+                  number: {{ $.Values.queryFrontend.http.port }}
   {{- end }}
 {{- end }}
 
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.grpc.ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.queryFrontend.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc
@@ -71,8 +73,10 @@ metadata:
 spec:
   {{- if .Values.queryFrontend.grpc.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc
-    servicePort: {{ $.Values.queryFrontend.grpc.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc
+      port:
+        number: {{ $.Values.queryFrontend.grpc.port }}
   {{- end }}
   {{- if .Values.queryFrontend.grpc.ingress.tls }}
   tls:
@@ -93,7 +97,9 @@ spec:
         paths:
           - path: {{ $.Values.queryFrontend.grpc.ingress.path }}
             backend:
-              serviceName: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc
-              servicePort: {{ $.Values.queryFrontend.grpc.port }}
+              service:
+                name: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc
+                port:
+                  number: {{ $.Values.queryFrontend.grpc.port }}
   {{- end }}
 {{- end }}

--- a/thanos/templates/query-frontend-ingress.yml
+++ b/thanos/templates/query-frontend-ingress.yml
@@ -20,8 +20,10 @@ metadata:
 spec:
   {{- if .Values.queryFrontend.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
-    servicePort: {{ $.Values.queryFrontend.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
+      port:
+        number: {{ $.Values.queryFrontend.http.port }}
   {{- end }}
   {{- if .Values.queryFrontend.http.ingress.tls }}
   tls:

--- a/thanos/templates/query-frontend-ingress.yml
+++ b/thanos/templates/query-frontend-ingress.yml
@@ -43,6 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.queryFrontend.http.ingress.path }}
+            pathType: {{ $.Values.queryFrontend.http.ingress.pathType }}
             backend:
               service:
                 name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
@@ -96,6 +97,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.queryFrontend.grpc.ingress.path }}
+            pathType: {{ $.Values.queryFrontend.grpc.ingress.pathType }}
             backend:
               service:
                 name: {{ include "thanos.componentname" (list $ "query-frontend") }}-grpc

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -43,6 +43,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.query.http.ingress.path }}
+          pathType: {{ $.Values.query.http.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "query") }}-http
@@ -96,6 +97,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.query.grpc.ingress.path }}
+          pathType: {{ $.Values.query.grpc.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "query") }}-grpc
@@ -103,3 +105,4 @@ spec:
                 number: {{ $.Values.query.grpc.port }}
   {{- end }}
 {{- end }}
+

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -44,14 +44,16 @@ spec:
       paths:
         - path: {{ $.Values.query.http.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
-            servicePort: {{ $.Values.query.http.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "query") }}-http
+              port:
+                number: {{ $.Values.query.http.port }}
   {{- end }}
 {{- end }}
 
 {{- if and .Values.query.enabled .Values.query.grpc.ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.query.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-grpc
@@ -71,8 +73,10 @@ metadata:
 spec:
   {{- if .Values.query.grpc.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
-    servicePort: {{ $.Values.query.grpc.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "query") }}-grpc
+      port:
+        number: {{ $.Values.query.grpc.port }}
   {{- end }}
   {{- if .Values.query.grpc.ingress.tls }}
   tls:
@@ -93,7 +97,9 @@ spec:
       paths:
         - path: {{ $.Values.query.grpc.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
-            servicePort: {{ $.Values.query.grpc.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "query") }}-grpc
+              port:
+                number: {{ $.Values.query.grpc.port }}
   {{- end }}
 {{- end }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -20,8 +20,10 @@ metadata:
 spec:
   {{- if .Values.query.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
-    servicePort: {{ $.Values.query.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "query") }}-http
+      port:
+        number: {{ $.Values.query.http.port }}
   {{- end }}
   {{- if .Values.query.http.ingress.tls }}
   tls:

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -20,8 +20,10 @@ metadata:
 spec:
   {{- if .Values.rule.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
-    servicePort: {{ $.Values.rule.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "rule") }}-http
+      port:
+        number: {{ $.Values.rule.http.port }}
   {{- end }}
   {{- if .Values.rule.http.ingress.tls }}
   tls:

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -43,6 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.rule.http.ingress.path }}
+            pathType: {{ $.Values.rule.http.ingress.pathType }}
             backend:
               service:
                 name: {{ include "thanos.componentname" (list $ "rule") }}-http
@@ -96,6 +97,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.rule.grpc.ingress.path }}
+            pathType: {{ $.Values.rule.grpc.ingress.pathType }}
             backend:
               service:
                 name: {{ include "thanos.componentname" (list $ "rule") }}-grpc

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -44,14 +44,16 @@ spec:
         paths:
           - path: {{ $.Values.rule.http.ingress.path }}
             backend:
-              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
-              servicePort: {{ $.Values.rule.http.port }}
+              service:
+                name: {{ include "thanos.componentname" (list $ "rule") }}-http
+                port:
+                  number: {{ $.Values.rule.http.port }}
   {{- end }}
 {{- end }}
 
 {{- if and .Values.rule.enabled .Values.rule.grpc.ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.rule.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "rule") }}-grpc
@@ -71,8 +73,10 @@ metadata:
 spec:
   {{- if .Values.rule.grpc.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
-    servicePort: {{ $.Values.rule.grpc.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+      port:
+        number: {{ $.Values.rule.grpc.port }}
   {{- end }}
   {{- if .Values.rule.grpc.ingress.tls }}
   tls:
@@ -93,7 +97,9 @@ spec:
         paths:
           - path: {{ $.Values.rule.grpc.ingress.path }}
             backend:
-              serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
-              servicePort: {{ $.Values.rule.grpc.port }}
+              service:
+                name: {{ include "thanos.componentname" (list $ "rule") }}-grpc
+                port:
+                  number: {{ $.Values.rule.grpc.port }}
   {{- end }}
 {{- end }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -43,6 +43,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.sidecar.http.ingress.path }}
+          pathType: {{ $.Values.sidecar.http.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "sidecar") }}-http
@@ -96,6 +97,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.sidecar.grpc.ingress.path }}
+          pathType: {{ $.Values.sidecar.grpc.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -44,14 +44,16 @@ spec:
       paths:
         - path: {{ $.Values.sidecar.http.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-http
-            servicePort: {{ $.Values.sidecar.http.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "sidecar") }}-http
+              port:
+                number: {{ $.Values.sidecar.http.port }}
   {{- end }}
 {{- end }}
 
 {{- if and .Values.sidecar.enabled .Values.sidecar.grpc.ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.sidecar.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
@@ -71,8 +73,10 @@ metadata:
 spec:
   {{- if .Values.sidecar.grpc.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
-    servicePort: {{ $.Values.sidecar.grpc.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
+      port:
+        number: {{ $.Values.sidecar.grpc.port }}
   {{- end }}
   {{- if .Values.sidecar.grpc.ingress.tls }}
   tls:
@@ -93,7 +97,9 @@ spec:
       paths:
         - path: {{ $.Values.sidecar.grpc.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
-            servicePort: {{ $.Values.sidecar.grpc.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
+              port:
+                number: {{ $.Values.sidecar.grpc.port }}
   {{- end }}
 {{- end }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -20,8 +20,10 @@ metadata:
 spec:
   {{- if .Values.sidecar.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-http
-    servicePort: {{ $.Values.sidecar.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "sidecar") }}-http
+      port:
+        number: {{ $.Values.sidecar.http.port }}
   {{- end }}
   {{- if .Values.sidecar.http.ingress.tls }}
   tls:

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -41,15 +41,17 @@ spec:
       paths:
         - path: {{ $.Values.store.http.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
-            servicePort: {{ $.Values.store.http.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "store") }}-http
+              port:
+                number: {{ $.Values.store.http.port }}
   {{- end }}
 {{- end }}
 
 ---
 
   {{- if and .Values.store.enabled .Values.store.grpc.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.sidecar.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-grpc
@@ -69,8 +71,10 @@ metadata:
 spec:
   {{- if .Values.store.grpc.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
-    servicePort: {{ $.Values.store.grpc.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "store") }}-grpc
+      port:
+        number: {{ $.Values.store.grpc.port }}
   {{- end }}
   {{- if .Values.store.grpc.ingress.tls }}
   tls:
@@ -89,7 +93,9 @@ spec:
       paths:
         - path: {{ $.Values.store.grpc.ingress.path }}
           backend:
-            serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
-            servicePort: {{ $.Values.store.grpc.port }}
+            service:
+              name: {{ include "thanos.componentname" (list $ "store") }}-grpc
+              port:
+                number: {{ $.Values.store.grpc.port }}
   {{- end }}
 {{- end }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -51,7 +51,7 @@ spec:
 ---
 
   {{- if and .Values.store.enabled .Values.store.grpc.ingress.enabled }}
-apiVersion: {{ .Values.sidecar.grpc.ingress.apiVersion }}
+apiVersion: {{ .Values.store.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-grpc

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -19,8 +19,10 @@ metadata:
 spec:
   {{- if .Values.store.http.ingress.defaultBackend }}
   backend:
-    serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
-    servicePort: {{ $.Values.store.http.port }}
+    service:
+      name: {{ include "thanos.componentname" (list $ "store") }}-http
+      port:
+        number: {{ $.Values.store.http.port }}
   {{- end }}
   {{- if .Values.store.http.ingress.tls }}
   tls:

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -40,6 +40,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.store.http.ingress.path }}
+          pathType: {{ $.Values.store.http.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "store") }}-http
@@ -51,7 +52,7 @@ spec:
 ---
 
   {{- if and .Values.store.enabled .Values.store.grpc.ingress.enabled }}
-apiVersion: {{ .Values.store.grpc.ingress.apiVersion }}
+apiVersion: {{ .Values.sidecar.grpc.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-grpc
@@ -92,6 +93,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.store.grpc.ingress.path }}
+          pathType: {{ $.Values.store.grpc.ingress.pathType }}
           backend:
             service:
               name: {{ include "thanos.componentname" (list $ "store") }}-grpc

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -97,6 +97,10 @@ store:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -127,11 +131,11 @@ store:
     # Set up ingress for the http service
     ingress:
       enabled: false
-      # Set default backend for ingress
 
-      apiVersion: extensions/v1beta1
       # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
 
+      # Set default backend for ingress
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -277,6 +281,10 @@ query:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -315,11 +323,11 @@ query:
     # Set up ingress for the http service
     ingress:
       enabled: false
-      # Set default backend for ingress
 
-      apiVersion: extensions/v1beta1
       # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
 
+      # Set default backend for ingress
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -445,6 +453,10 @@ queryFrontend:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -480,6 +492,10 @@ queryFrontend:
     # Set up ingress for the http service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -746,11 +762,11 @@ bucket:
     # Set up ingress for the http service
     ingress:
       enabled: false
-      # Set default backend for ingress
 
-      apiVersion: extensions/v1beta1
       # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
 
+      # Set default backend for ingress
       defaultBackend: false
       annotations: {}
       # kubernetes.io/ingress.class: nginx
@@ -945,6 +961,10 @@ rule:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -976,11 +996,11 @@ rule:
     # Set up ingress for the http service
     ingress:
       enabled: false
-      # Set default backend for ingress
 
-      apiVersion: extensions/v1beta1
       # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
 
+      # Set default backend for ingress
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
@@ -1083,6 +1103,10 @@ sidecar:
     # Set up ingress for the grpc service
     ingress:
       enabled: false
+
+      # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
+
       # Set default backend for ingress
       defaultBackend: false
       annotations: {}
@@ -1112,11 +1136,11 @@ sidecar:
     # Set up ingress for the http service
     ingress:
       enabled: false
-      # Set default backend for ingress
 
-      apiVersion: extensions/v1beta1
       # Set API version for ingress
+      apiVersion: networking.k8s.io/v1
 
+      # Set default backend for ingress
       defaultBackend: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -108,6 +108,7 @@ store:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -142,6 +143,7 @@ store:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -292,6 +294,7 @@ query:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -334,6 +337,7 @@ query:
         # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -464,6 +468,7 @@ queryFrontend:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -503,6 +508,7 @@ queryFrontend:
         # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -773,6 +779,7 @@ bucket:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -972,6 +979,7 @@ rule:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -1007,6 +1015,7 @@ rule:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -1114,6 +1123,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -1147,6 +1157,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []


### PR DESCRIPTION
quick fix to allow for upgraded ingress versions required by kubernetes 1.23 and later as detailed here https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
quick fix to allow for upgraded ingress versions required by kubernetes 1.23 and later as detailed here https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
kubernetes 1.23 and later no longer supports some of the current hardcoded values in the spec; specifically, backend.serviceName and backend.servicePort are both deprecated

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
