### PR TITLE
[Thanos] Fix query-frontend.log-queries-longer-than argument

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.3
+version: 0.4.4
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/query-frontend-deployment.yaml
+++ b/thanos/templates/query-frontend-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - "--query-frontend.compress-responses"
         {{- end }}
         {{- if .Values.queryFrontend.logQueriesLongerThan }}
-        - "--query-frontend.log_queries_longer_than={{ .Values.queryFrontend.logQueriesLongerThan }}"
+        - "--query-frontend.log-queries-longer-than={{ .Values.queryFrontend.logQueriesLongerThan }}"
         {{- end }}
         {{- if .Values.queryFrontend.queryRange.cache.inMemory }}
         - |-


### PR DESCRIPTION
Fixes a typo in the --query-frontend.log-queries-longer-than argument of the query-frontend-deployment.yaml.  The chart currently produces: `--query-frontend.log_queries_longer_than` using underscores. The correct argument should be `--query-frontend.log-queries-longer-than` using dashes. 


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Corrects typo for the --query-frontend.log-queries-longer-than argument of the query-frontend-deployment.yaml 


### Why?
The container fails to start when setting the queryFrontend.logQueriesLongerThan value to something other than 0.


### Additional context

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

