### PR TITLE
Fix:

### DIFF
--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -6,7 +6,7 @@ Metrics Server is a cluster-wide aggregator of resource usage data.
 
 Parameter | Description | Default
 --- | --- | ---
-`rbac.create` | Enable Role-based authentication | `true`
+`rbac.enabled` | Enable Role-based authentication | `true`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
 `apiService.create` | Create the v1beta1.metrics.k8s.io API service | `true`

--- a/metrics-server/templates/auth-delegator-crb.yaml
+++ b/metrics-server/templates/auth-delegator-crb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/metrics-server/templates/cluster-role.yaml
+++ b/metrics-server/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/metrics-server/templates/metrics-server-crb.yaml
+++ b/metrics-server/templates/metrics-server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Replaced .Values.rbac.create with .Values.rbac.enabled used in IF statements in several templates to match default Values and other templates.
Changed README.md to match changes and describe proper usage of a chart

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no related ticket
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
There is en issue with deploying metrics-server chart with default values, in some templates value rbac.enabled is used but in others rbac.create. This is confusing and rbac,create is not in default values. This PR cleans that up by making all templates use rbac.enabled.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Paragraph above explains it 



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

