### PR TITLE
Made Cadence metrics reporter services mutually exclusive

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.18.0
+version: 0.19.0
 appVersion: 0.20.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -220,6 +220,19 @@ and create a domain:
 docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --domain samples-domain domain register --global_domain false
 ```
 
+## Metrics
+
+Note: from chart version 0.19.0, the metrics collection services (Prometheus,
+StatsD) are mutually exclusive - only one of those can be enabled at the same
+time based on the values configuration. The default configuration enables
+Prometheus.
+
+If you want to enable StatsD (and disable Prometheus), you may edit the global
+metrics configuration values accordingly. If you want to use them in a mixed
+fashion, make sure to disable both in the global metrics configuration values
+and enable the desired one in the service-specific configuration values (this is
+required, because global configurations take precedence over service-specific
+configurations).
 
 ## Configuration
 

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -83,10 +83,11 @@ data:
         metrics:
           tags:
             type: frontend
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.frontend.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
-        {{- if or .Values.server.metrics.statsd .Values.server.frontend.metrics.statsd }}
+        {{- else if or .Values.server.metrics.statsd .Values.server.frontend.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.frontend.metrics.statsd.hostPort | quote }}
             prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.frontend" }}` }}
@@ -99,10 +100,11 @@ data:
         metrics:
           tags:
             type: history
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.history.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
-        {{- if or .Values.server.metrics.statsd .Values.server.history.metrics.statsd }}
+        {{- else if or .Values.server.metrics.statsd .Values.server.history.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.history.metrics.statsd.hostPort | quote }}
             prefix: {{ `{{ default .Env.STATSD_HISTORY_PREFIX "cadence.history" }}` }}
@@ -115,10 +117,11 @@ data:
         metrics:
           tags:
             type: matching
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.matching.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
-        {{- if or .Values.server.metrics.statsd .Values.server.matching.metrics.statsd }}
+        {{- else if or .Values.server.metrics.statsd .Values.server.matching.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.matching.metrics.statsd.hostPort | quote }}
             prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.matching" }}` }}
@@ -131,10 +134,11 @@ data:
         metrics:
           tags:
             type: worker
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
-        {{- if or .Values.server.metrics.statsd .Values.server.worker.metrics.statsd }}
+        {{- else if or .Values.server.metrics.statsd .Values.server.worker.metrics.statsd }}
           statsd:
             hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.worker.metrics.statsd.hostPort | quote }}
             prefix: {{ `{{ default .Env.STATSD_WORKER_PREFIX "cadence.worker" }}` }}


### PR DESCRIPTION
Reasoning: https://github.com/banzaicloud/banzai-charts/issues/1250

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | resolves #1250 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Made Cadence metrics reporter services mutually exclusive.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

From  https://github.com/uber/cadence/pull/4180 multiple metrics reporters would cause an error on startup (see #1250 for more details).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Decided to increment minor version due to the change being a breaking chart behavior change for configurations where both metrics reporter services are enabled.

Tested with the regular chart upgrade test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Tag new version once merged.
