### PR TITLE
Upgraded Cadence server 0.20.0->0.21.0, web 3.24.0->3.26.0, chart 0.19.0->0.20.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.19.0
-appVersion: 0.20.0
+version: 0.20.0
+appVersion: 0.21.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.20.0+
+- Cadence 0.21.0+
 
 
 ## Installing the Chart
@@ -244,7 +244,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.20.0`              |
+| `server.image.tag`                                | Server image tag                                      | `0.21.0`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |
@@ -280,7 +280,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.enabled`                                     | Enable WebUI service                                  | `true`                |
 | `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
-| `web.image.tag`                                   | WebUI image tag                                       | `3.22.2`              |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.26.0`              |
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
 | `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |

--- a/cadence/docs/chart_upgrade.md
+++ b/cadence/docs/chart_upgrade.md
@@ -70,6 +70,20 @@ section II. should be skipped.
    API's libraries and binaries (and the public interface of those) with an
    emphasis on the static configuration.
 
+4. Check the available [Cadence web
+   tags](https://github.com/uber/cadence-web/tags).
+
+   If there is a **web version** to upgrade to, pick the latest
+   available patch version of the chosen minor version.
+
+5. Note down any potential major (breaking) change between the last **chart
+   supported** web version and the chosen next web version. Breaking
+   changes are usually listed as notes or breaking changes at the upstream tag
+   description.
+
+6. Make sure the selected **web version** is compatible with the chosen **server
+   version** (the latter takes precedence when determining the baseline).
+
 ## III. Determine the new chart version
 
 [Note: major version 0.Minor.Patch may contain breaking changes in any version
@@ -110,19 +124,22 @@ breaking changes of major version 0.Minor.Patch.
       version**,
 
    2. Also update the default value of the [`Configuration / server.image.tag`
-      parameter in the `cadence/README.md`](../README.md#Configuration) to the
-      new **server version**,
+      and optionally the `Configuration / web.image.tag` parameters in the
+      `cadence/README.md`](../README.md#Configuration) to the new **server
+      version** and **web version** respectively,
 
    3. update the chart's default application version at the [`appVersion` field
       in the `cadence/Chart.yaml`](../Chart.yaml)'s to the new **server
       version**,
 
-   4. update the image tag version at the [`server.image.tag` field in the
+   4. update the image tag version at the [`server.image.tag`  and optionally
+      the `web.image.tag` fields in the
       `cadence/values.yaml`](../values.yaml)'s, to the new **server version**
+      and **web version** respectively.
 
 3. Update the chart's version at the [`version` field in the
    `cadence/Chart.yaml`](../Chart.yaml)'s to the newly determined **chart
-   version**,
+   version**.
 
 4. **If there are any minor or major (breaking) changes affecting the chart,
    update the chart files accordingly to incorporate those changes.** Make sure
@@ -176,7 +193,13 @@ method.
    yq eval ".pipeline.configuration.cloudinfo.endpoint = \"${YOUR_CLOUDINFO_INSTANCE_ENDPOINT}\"" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
    ```
 
-   c, You **MAY** change the workspace `values.yaml` 's ` installer.image` value
+   c, You **MUST** enable the Cadence web frontend in case you need it.
+
+   ```shell
+   yq eval ".cadence.web.enabled = true" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
+   ```
+
+   d, You **MAY** change the workspace `values.yaml` 's ` installer.image` value
    to `banzaicloud/pipeline-installer:latest` so it always uses the latest
    available tag, automatically keeping it up to date.
 
@@ -184,7 +207,7 @@ method.
    yq eval ".installer.image = \"$(yq eval .installer.image ${BANZAI_INSTALLER_WORKSPACE_VALUES} | sed -E 's/banzaicloud\/pipeline\-installer\@sha256\:.+/banzaicloud\/pipeline\-installer\:latest/g')\"" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
    ```
 
-   d, You **MAY** also change the Kind cluster name to a unique one to avoid
+   e, You **MAY** also change the Kind cluster name to a unique one to avoid
    name clashing.
 
    ```shell
@@ -195,6 +218,9 @@ method.
    look like the following:
 
    ```shell
+   cadence:
+      web:
+         enabled: true
    defaultStorageBackend: mysql
    externalHost: default.localhost.banzaicloud.io
    ingressHostPort: true
@@ -338,7 +364,18 @@ method.
     watch banzai cluster list
     ```
 
-21. Tear down the Kind control plane cluster.
+21. If you want to check the Cadence web frontend you **MUST** port forward the
+    pod's port locally.
+
+    ```shell
+    KUBERNETES_POD_NAME_CADENCE_WEB="$(kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pod --selector "app.kubernetes.io/instance=cadence,app.kubernetes.io/component=web" -o name)"
+    kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud port-forward "${KUBERNETES_POD_NAME_CADENCE_WEB}" 8088:8088
+    ```
+
+    Then as long as the port forwarding is active, you can view the Cadence web
+    at http://localhost:8088.
+
+22. Tear down the Kind control plane cluster.
 
     ```shell
     banzai pipeline down --workspace ${BANZAI_INSTALLER_WORKSPACE}

--- a/cadence/templates/_helpers.tpl
+++ b/cadence/templates/_helpers.tpl
@@ -53,12 +53,24 @@ Source: https://stackoverflow.com/a/52024583/3027614
 {{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
 {{- end }}
 
+{{- define "cadence.frontend.internalGRPCPort" -}}
+7833
+{{- end -}}
+
 {{- define "cadence.frontend.internalPort" -}}
 7933
 {{- end -}}
 
+{{- define "cadence.history.internalGRPCPort" -}}
+7834
+{{- end -}}
+
 {{- define "cadence.history.internalPort" -}}
 7934
+{{- end -}}
+
+{{- define "cadence.matching.internalGRPCPort" -}}
+7835
 {{- end -}}
 
 {{- define "cadence.matching.internalPort" -}}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -69,16 +69,16 @@ data:
       name: cadence
       bootstrapMode: dns
       bootstrapHosts:
-        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port }}
-        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port }}
-        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port }}
-        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port }}
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ .Env.WORKER_PORT | default 7939 }}` }}
       maxJoinDuration: 30s
 
     services:
       frontend:
         rpc:
-          port: {{ include "cadence.frontend.internalPort" . }}
+          port: {{ include "cadence.frontend.internalPort" . | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -95,7 +95,7 @@ data:
 
       history:
         rpc:
-          port: {{ include "cadence.history.internalPort" . }}
+          port: {{ include "cadence.history.internalPort" . | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -112,7 +112,7 @@ data:
 
       matching:
         rpc:
-          port: {{ include "cadence.matching.internalPort" . }}
+          port: {{ include "cadence.matching.internalPort" . | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -129,7 +129,7 @@ data:
 
       worker:
         rpc:
-          port: {{ include "cadence.worker.internalPort" . }}
+          port: {{ include "cadence.worker.internalPort" . | default `{{ .Env.WORKER_PORT | default 7939 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -158,13 +158,13 @@ data:
           enabled: true
           initialFailoverVersion: 0
           rpcName: "cadence-frontend"
-          rpcAddress: {{ `{{ default .Env.PRIMARY_SEEDS "cadence" }}` }}:7933
+          rpcAddress: {{ `{{ .Env.PRIMARY_FRONTEND_SERVICE | default "cadence" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
       {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }}
         secondary:
             enabled: true
             initialFailoverVersion: 2
             rpcName: "cadence-frontend"
-            rpcAddress: {{ `{{ default .Env.SECONDARY_SEEDS "cadence-secondary" }}` }}:7933
+            rpcAddress: {{ `{{ .Env.SECONDARY_FRONTEND_SERVICE | default "cadence-secondary" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
       {{- end }}
 
     dcRedirectionPolicy:
@@ -175,7 +175,7 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "{{ include "cadence.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"
+      hostPort: "{{ include "cadence.componentname" (list . "frontend") | default `{{ .Env.FRONTEND_SERVICE | default "127.0.0.1" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}"
 
     dynamicConfigClient:
       filepath: "/etc/cadence/config/dynamicconfig/config.yaml"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -70,8 +70,11 @@ data:
       name: cadence
       bootstrapMode: dns
       bootstrapHosts:
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ .Env.FRONTEND_GRPC_PORT | default 7833 }}` }}
         - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ .Env.HISTORY_GRPC_PORT | default 7834 }}` }}
         - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ .Env.MATCHING_GRPC_PORT | default 7835 }}` }}
         - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
         - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ .Env.WORKER_PORT | default 7939 }}` }}
       maxJoinDuration: 30s
@@ -79,6 +82,7 @@ data:
     services:
       frontend:
         rpc:
+          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ .Env.FRONTEND_GRPC_PORT | default 7833 }}` }}
           port: {{ include "cadence.frontend.internalPort" . | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
@@ -96,6 +100,7 @@ data:
 
       history:
         rpc:
+          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ .Env.HISTORY_GRPC_PORT | default 7834 }}` }}
           port: {{ include "cadence.history.internalPort" . | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
@@ -113,6 +118,7 @@ data:
 
       matching:
         rpc:
+          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ .Env.MATCHING_GRPC_PORT | default 7835 }}` }}
           port: {{ include "cadence.matching.internalPort" . | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -14,6 +14,7 @@ data:
     log:
       stdout: true
       level: {{ .Values.server.config.logLevel | quote }}
+      levelKey: "level"
 
     persistence:
       defaultStore: default

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -127,6 +127,7 @@ server:
     # replicaCount: 1
     service:
       type: ClusterIP
+      grpcPort: 7833
       port: 7933
     metrics:
       annotations: {}
@@ -149,6 +150,7 @@ server:
     # replicaCount: 1
     service:
       # type: ClusterIP
+      grpcPort: 7834
       port: 7934
     metrics:
       annotations: {}
@@ -171,6 +173,7 @@ server:
     # replicaCount: 1
     service:
       # type: ClusterIP
+      grpcPort: 7835
       port: 7935
     metrics:
       annotations: {}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.20.0
+    tag: 0.21.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -221,7 +221,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: v3.24.0
+    tag: v3.26.0
     pullPolicy: IfNotPresent
 
   tcheck:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated Cadence server 0.20.0->0.21.0, web 3.24.0->3.26.0.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To support the latest available server version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

1. Added environment variable service ports based on uber/cadence#4084.
2. Added baked in log level key based on uber/cadence#4120.
3. Added GRPC port configuration based on uber/cadence#4057 and uber/cadence#4146.

Tested with the regular method along with checking the web frontend.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] Wait for #1255 before merging for version continuity.
