### PR TITLE
Fixed Cadence mixed Helm, dockerize defaults

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.20.0
+version: 0.20.1
 appVersion: 0.21.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -70,20 +70,20 @@ data:
       name: cadence
       bootstrapMode: dns
       bootstrapHosts:
-        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ .Env.FRONTEND_GRPC_PORT | default 7833 }}` }}
-        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
-        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ .Env.HISTORY_GRPC_PORT | default 7834 }}` }}
-        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
-        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ .Env.MATCHING_GRPC_PORT | default 7835 }}` }}
-        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
-        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ .Env.WORKER_PORT | default 7939 }}` }}
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ default .Env.HISTORY_PORT 7934 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ default .Env.WORKER_PORT 7939 }}` }}
       maxJoinDuration: 30s
 
     services:
       frontend:
         rpc:
-          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ .Env.FRONTEND_GRPC_PORT | default 7833 }}` }}
-          port: {{ include "cadence.frontend.internalPort" . | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
+          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+          port: {{ include "cadence.frontend.internalPort" . | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -100,8 +100,8 @@ data:
 
       history:
         rpc:
-          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ .Env.HISTORY_GRPC_PORT | default 7834 }}` }}
-          port: {{ include "cadence.history.internalPort" . | default `{{ .Env.HISTORY_PORT | default 7934 }}` }}
+          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+          port: {{ include "cadence.history.internalPort" . | default `{{ default .Env.HISTORY_PORT default 7934 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -118,8 +118,8 @@ data:
 
       matching:
         rpc:
-          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ .Env.MATCHING_GRPC_PORT | default 7835 }}` }}
-          port: {{ include "cadence.matching.internalPort" . | default `{{ .Env.MATCHING_PORT | default 7935 }}` }}
+          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+          port: {{ include "cadence.matching.internalPort" . | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -136,7 +136,7 @@ data:
 
       worker:
         rpc:
-          port: {{ include "cadence.worker.internalPort" . | default `{{ .Env.WORKER_PORT | default 7939 }}` }}
+          port: {{ include "cadence.worker.internalPort" . | default `{{ default .Env.WORKER_PORT 7939 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -165,13 +165,13 @@ data:
           enabled: true
           initialFailoverVersion: 0
           rpcName: "cadence-frontend"
-          rpcAddress: {{ `{{ .Env.PRIMARY_FRONTEND_SERVICE | default "cadence" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
+          rpcAddress: {{ `{{ default .Env.PRIMARY_FRONTEND_SERVICE "cadence" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
       {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }}
         secondary:
             enabled: true
             initialFailoverVersion: 2
             rpcName: "cadence-frontend"
-            rpcAddress: {{ `{{ .Env.SECONDARY_FRONTEND_SERVICE | default "cadence-secondary" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}
+            rpcAddress: {{ `{{ default .Env.SECONDARY_FRONTEND_SERVICE "cadence-secondary" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
       {{- end }}
 
     dcRedirectionPolicy:
@@ -182,7 +182,7 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "{{ include "cadence.componentname" (list . "frontend") | default `{{ .Env.FRONTEND_SERVICE | default "127.0.0.1" }}` }}:{{ .Values.server.frontend.service.port | default `{{ .Env.FRONTEND_PORT | default 7933 }}` }}"
+      hostPort: "{{ include "cadence.componentname" (list . "frontend") | default `{{ default .Env.FRONTEND_SERVICE "127.0.0.1" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}"
 
     dynamicConfigClient:
       filepath: "/etc/cadence/config/dynamicconfig/config.yaml"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed Cadence mixed Helm, dockerize defaults.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To correct it.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Helm YAML Go text/templates and [jwilder/dockerize](https://github.com/jwilder/dockerize)'s docker YAML Go text/templates - which is used by Cadence internally - define the `default` function with different argument order. 
Helm [defines](https://helm.sh/docs/chart_template_guide/function_list/#default) it with `default-value object` argument order.
[jwilder/dockerize](https://github.com/jwilder/dockerize) [defines](https://github.com/jwilder/dockerize/blob/593463c740bef4ae528b59d7b919816a18ff184d/template.go#L36) it with `object default-value` argument order.

We use both due to mixing Helm level templating and occasionally generating dockerize level templates into the docker configuration file.

I messed the mixing up when I was importing the changes of the new server version.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] Release fix version.
