### PR TITLE
option to add pathType for Ingress k8s > v1.18

### DIFF
--- a/thanos/templates/bucket-ingress.yaml
+++ b/thanos/templates/bucket-ingress.yaml
@@ -38,6 +38,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.bucket.http.ingress.path }}
+          pathType: {{ $.Values.bucket.http.ingress.pathType }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
             servicePort: {{ $.Values.bucket.http.port }}

--- a/thanos/templates/query-ingress.yml
+++ b/thanos/templates/query-ingress.yml
@@ -41,6 +41,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.query.http.ingress.path }}
+          pathType: {{ $.Values.query.http.ingress.pathType }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
             servicePort: {{ $.Values.query.http.port }}
@@ -90,6 +91,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.query.grpc.ingress.path }}
+          pathType: {{ $.Values.query.http.ingress.pathType }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
             servicePort: {{ $.Values.query.grpc.port }}

--- a/thanos/templates/rule-ingress.yml
+++ b/thanos/templates/rule-ingress.yml
@@ -41,6 +41,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.rule.http.ingress.path }}
+            pathType: {{ $.Values.rule.http.ingress.pathType }}
             backend:
               serviceName: {{ include "thanos.componentname" (list $ "rule") }}-http
               servicePort: {{ $.Values.rule.http.port }}
@@ -90,6 +91,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.rule.grpc.ingress.path }}
+            pathType: {{ $.Values.rule.http.ingress.pathType }}            
             backend:
               serviceName: {{ include "thanos.componentname" (list $ "rule") }}-grpc
               servicePort: {{ $.Values.rule.grpc.port }}

--- a/thanos/templates/sidecar-ingress.yaml
+++ b/thanos/templates/sidecar-ingress.yaml
@@ -41,6 +41,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.sidecar.http.ingress.path }}
+          pathType: {{ $.Values.sidecar.http.ingress.pathType }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-http
             servicePort: {{ $.Values.sidecar.http.port }}
@@ -90,6 +91,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.sidecar.grpc.ingress.path }}
+          pathType: {{ $.Values.sidecar.http.ingress.pathType }}        
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
             servicePort: {{ $.Values.sidecar.grpc.port }}

--- a/thanos/templates/store-ingress.yaml
+++ b/thanos/templates/store-ingress.yaml
@@ -38,6 +38,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.store.http.ingress.path }}
+          pathType: {{ $.Values.store.http.ingress.pathType }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
             servicePort: {{ $.Values.store.http.port }}
@@ -86,6 +87,7 @@ spec:
     http:
       paths:
         - path: {{ $.Values.store.grpc.ingress.path }}
+          pathType: {{ $.Values.store.http.ingress.pathType }}          
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
             servicePort: {{ $.Values.store.grpc.port }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -104,6 +104,7 @@ store:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -138,6 +139,7 @@ store:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -284,6 +286,7 @@ query:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -326,6 +329,7 @@ query:
         # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -452,6 +456,7 @@ queryFrontend:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -487,6 +492,7 @@ queryFrontend:
         # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -757,6 +763,7 @@ bucket:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -952,6 +959,7 @@ rule:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -987,6 +995,7 @@ rule:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -1090,6 +1099,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []
@@ -1123,6 +1133,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: "Prefix"
       hosts:
         - "/"
       tls: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- In k8s v1.18 onwards the default ingress pathType is `IngressClass`. This PR has option to define the custom pathType for users.  -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)


