### PR TITLE
Changed the Cadence chart's `enableGlobalDomain` default value false->true

### DIFF
--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -152,7 +152,7 @@ data:
         {{- end}}
 
     clusterMetadata:
-      enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}` }}
+      enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "true" }}` }}
       failoverVersionIncrement: 10
       masterClusterName: "primary"
     {{- if `{{ .Env.IS_NOT_PRIMARY }}` }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1267 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Changed the Cadence chart's `enableGlobalDomain` default value false->true.
The domains created with the default value in the future will implicitly be global domains instead of locals unless explicitly specified otherwise on the domain creation request. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Cadence is deprecating local domains in https://github.com/uber/cadence/pull/4279 and defaults to global domains. We are following the recommendation made through https://github.com/banzaicloud/banzai-charts/issues/1267.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested with the regular chart update test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
