### PR TITLE
Fix grafana-operator deployment to recreate instances instead of rolling new version out to avoid deadlock

### DIFF
--- a/grafana-operator/Chart.yaml
+++ b/grafana-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: grafana-operator
 description: Grafana-operator Helm chart for Kubernetes
 
-version: 0.3.10
+version: 0.3.11
 
 appVersion: master
 

--- a/grafana-operator/values.yaml
+++ b/grafana-operator/values.yaml
@@ -33,7 +33,7 @@ replicaCount: 1
 ##    maxUnavailable: 25%
 ##
 updateStrategy:
-  type: RollingUpdate
+  type: Recreate
 
 ## Deploy CRDs
 ##


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Change the strategy type to recreate instances instead of using rolling update.


### Why?
To avoid deadlock when a new instance cannot start because it waits for the lock held by the old instance, which cannot be stopped until the new instance comes up.
