### PR TITLE
Adding service monitor

### DIFF
--- a/spot-termination-exporter/Chart.yaml
+++ b/spot-termination-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: spot-termination-exporter
 home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/banzai-charts
-version: 0.1.0
+version: 0.0.10
 description: Spot Termination exporter Helm chart for Kubernetes
 keywords:
 - spot

--- a/spot-termination-exporter/Chart.yaml
+++ b/spot-termination-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: spot-termination-exporter
 home: https://banzaicloud.com
 sources:
   - https://github.com/banzaicloud/banzai-charts
-version: 0.0.9
+version: 0.1.0
 description: Spot Termination exporter Helm chart for Kubernetes
 keywords:
 - spot

--- a/spot-termination-exporter/templates/servicemonitor.yaml
+++ b/spot-termination-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if .Values.spotTerminationexporter.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/spot-termination-exporter/templates/servicemonitor.yaml
+++ b/spot-termination-exporter/templates/servicemonitor.yaml
@@ -6,11 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "spotTerminationexporter.name" . }}
-    chart: {{ template "spotTerminationexporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- if .Values.spotTerminationexporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.spotTerminationexporter.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/spot-termination-exporter/templates/servicemonitor.yaml
+++ b/spot-termination-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "spotTerminationexporter.fullname" .  }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "spotTerminationexporter.name" . }}
+    chart: {{ template "spotTerminationexporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: http
+  jobLabel: {{ include "spotTerminationexporter.name" . }}
+  namespaceSelector:
+    matchNames:
+    - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ include "spotTerminationexporter.name" . }}
+{{ end }}

--- a/spot-termination-exporter/values.yaml
+++ b/spot-termination-exporter/values.yaml
@@ -36,16 +36,9 @@ spotTerminationexporter:
   serviceMonitor:
     # enabled should be set to true to enable prometheus-operator discovery of this service
     enabled: true
-    # interval is the interval at which metrics should be scraped
-    # interval: 30s
-    # scrapeTimeout is the timeout after which the scrape is ended
-    # scrapeTimeout: 10s
     # additionalLabels is the set of additional labels to add to the ServiceMonitor
     additionalLabels: {}
     jobLabel: ""
-    targetLabels: []
-    podTargetLabels: []
-    metricRelabelings: []
 
   logLevel: "debug"
 

--- a/spot-termination-exporter/values.yaml
+++ b/spot-termination-exporter/values.yaml
@@ -32,7 +32,20 @@ spotTerminationexporter:
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     ##
     # annotations:
-
+  
+  serviceMonitor:
+    # enabled should be set to true to enable prometheus-operator discovery of this service
+    enabled: true
+    # interval is the interval at which metrics should be scraped
+    # interval: 30s
+    # scrapeTimeout is the timeout after which the scrape is ended
+    # scrapeTimeout: 10s
+    # additionalLabels is the set of additional labels to add to the ServiceMonitor
+    additionalLabels: {}
+    jobLabel: ""
+    targetLabels: []
+    podTargetLabels: []
+    metricRelabelings: []
 
   logLevel: "debug"
 

--- a/spot-termination-exporter/values.yaml
+++ b/spot-termination-exporter/values.yaml
@@ -38,7 +38,6 @@ spotTerminationexporter:
     enabled: true
     # additionalLabels is the set of additional labels to add to the ServiceMonitor
     additionalLabels: {}
-    jobLabel: ""
 
   logLevel: "debug"
 

--- a/spot-termination-exporter/values.yaml
+++ b/spot-termination-exporter/values.yaml
@@ -35,7 +35,7 @@ spotTerminationexporter:
   
   serviceMonitor:
     # enabled should be set to true to enable prometheus-operator discovery of this service
-    enabled: true
+    enabled: false
     # additionalLabels is the set of additional labels to add to the ServiceMonitor
     additionalLabels: {}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | nil
| License         | Apache 2.0

### What's in this PR?
This PR adds service monitor object for spot-termination-exporter helm-chart

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To monitor this service from prometheus operator we need this added in template

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
