### PR TITLE
Use nindent instead of indent to fix yaml parsing

### DIFF
--- a/thanos/templates/rule-configmap.yaml
+++ b/thanos/templates/rule-configmap.yaml
@@ -14,6 +14,6 @@ data:
   {{- $root := . -}}
   {{- range $key, $value := .Values.rule.ruleFiles }}
   {{ $key }}: |
-{{ toYaml $value | default "{}" | nindent 4 }}
+  {{- toYaml $value | default "{}" | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/thanos/templates/rule-configmap.yaml
+++ b/thanos/templates/rule-configmap.yaml
@@ -14,6 +14,6 @@ data:
   {{- $root := . -}}
   {{- range $key, $value := .Values.rule.ruleFiles }}
   {{ $key }}: |
-{{ toYaml $value | default "{}" | indent 4 }}
+{{ toYaml $value | default "{}" | nindent 4 }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1113
| License         | Apache 2.0


### What's in this PR?
Small function change

### Why?
Fixes a bug in generating the rule configmap


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
