### PR TITLE
Added Cadence clusterMetadata configuration

### DIFF
--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -155,11 +155,7 @@ data:
       enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "true" }}` }}
       failoverVersionIncrement: 10
       masterClusterName: "primary"
-    {{- if `{{ .Env.IS_NOT_PRIMARY }}` }}
-      currentClusterName: "secondary"
-    {{- else }}
       currentClusterName: "primary"
-    {{- end }}
       clusterInformation:
         primary:
           enabled: true
@@ -182,7 +178,7 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "{{ include "cadence.componentname" (list . "frontend") | default `{{ default .Env.FRONTEND_SERVICE "127.0.0.1" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}"
+      hostPort: "{{ include "cadence.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"
 
     dynamicConfigClient:
       filepath: "/etc/cadence/config/dynamicconfig/config.yaml"

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -152,22 +152,22 @@ data:
         {{- end}}
 
     clusterMetadata:
-      enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "true" }}` }}
-      failoverVersionIncrement: 10
-      masterClusterName: "primary"
-      currentClusterName: "primary"
+      enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomains }}
+      failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
+      masterClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
+      currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}
       clusterInformation:
-        primary:
-          enabled: true
-          initialFailoverVersion: 0
-          rpcName: "cadence-frontend"
-          rpcAddress: {{ `{{ default .Env.PRIMARY_FRONTEND_SERVICE "cadence" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
-      {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }}
-        secondary:
-            enabled: true
-            initialFailoverVersion: 2
-            rpcName: "cadence-frontend"
-            rpcAddress: {{ `{{ default .Env.SECONDARY_FRONTEND_SERVICE "cadence-secondary" }}` }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
+      {{- $currentClusterName := .Values.server.config.clusterMetadata.currentClusterName }}
+      {{- $currentClusterIndex := 0 }}
+      {{- $frontendComponentName := (include "cadence.componentname" (list . "frontend")) }}
+      {{- $serverFrontendServicePort := .Values.server.frontend.service.port }}
+      {{- range $clusterIndex, $clusterInfo := .Values.server.config.clusterMetadata.clusterInformation }}
+        {{- if eq $clusterInfo.name $currentClusterName }}{{ $currentClusterIndex = $clusterIndex }}{{ end }}
+        {{ $clusterInfo.name }}:
+          enabled: {{ $clusterInfo.enabled }}
+          initialFailoverVersion: {{ $clusterIndex }}
+          rpcName: "{{ $frontendComponentName }}"
+          rpcAddress: "{{ $clusterInfo.rpcAddress | default (printf "%s%s%.0f" $frontendComponentName ":" $serverFrontendServicePort ) }}"
       {{- end }}
 
     dcRedirectionPolicy:
@@ -178,7 +178,8 @@ data:
       status: "disabled"
 
     publicClient:
-      hostPort: "{{ include "cadence.componentname" (list . "frontend") }}:{{ .Values.server.frontend.service.port }}"
+      {{- $currentClusterInfo := (index .Values.server.config.clusterMetadata.clusterInformation $currentClusterIndex) }}
+      hostPort:  "{{ $currentClusterInfo.rpcAddress | default (printf "%s%s%.0f" $frontendComponentName ":" $serverFrontendServicePort ) }}"
 
     dynamicConfigClient:
       filepath: "/etc/cadence/config/dynamicconfig/config.yaml"

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -57,6 +57,90 @@ server:
   affinity: {}
 
   config:
+    # clusterMetadata contains the settings of the Cadence clusters
+    # participating in a Cadence cluster group.
+    clusterMetadata:
+      # enableGlobalDomain when set to true allows creating global domains which
+      # are replicated between all Cadence clusters distributed among different
+      # Kubernetes clusters and whose tasks are served by the active Cadence
+      # cluster in the replication.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the first
+      # Cadence cluster of the Cadence cluster group.
+      enableGlobalDomain: true
+
+      # maximumClusterCount defines and locks the maximum number of Cadence
+      # clusters of a Cadence cluster group at any point in the future included
+      # clusters added later.
+      #
+      # The requirement for this is to be able to safely determine a
+      # failoverVersionIncrement and initialFailoverVersion for each cluster
+      # automatically, accounting for clusters which are potentially being added
+      # later on to the cluster group and ensuring unique failover versions for
+      # each cluster all the time.
+      #
+      # failoverVersionIncrement is the increment of each cluster version when
+      # failover happens.
+      #
+      # initialFailoverVersion is the failover version a cluster starts at when
+      # launched.
+      #
+      # WARNING: For each Cadence cluster, (initialFailoverVersion +
+      # i*failoverVersionIncrement) **MUST** result in a unique value, not used
+      # by any other cluster.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the first
+      # Cadence cluster of the Cadence cluster group.
+      maximumClusterCount: 100
+
+      # masterClusterName is the name of the Cadence leader cluster in a Cadence
+      # cluster group which can register a domain, while each cluster can update
+      # domains and do domain failover.
+      #
+      # WARNING: it **MUST** be set to the same value for all Cadence clusters
+      # in a Cadence cluster group.
+      masterClusterName: "cluster-0"
+
+      # currentClusterName is the name of the Cadence cluster the configuration
+      # belongs to.
+      #
+      # In a Cadence cluster group, this is the particular Cadence
+      # cluster being installed with the chart on a Kubernetes cluster.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the Cadence
+      # cluster.
+      currentClusterName: "cluster-0"
+      
+      # clusterInformation contains the information about each Cadence cluster
+      # which participates in a Cadence cluster group.
+      #
+      # WARNING: for each Cadence cluster at any moment, the cluster names,
+      # initialFailoverVersion values and (initialFailoverVersion +
+      # i*failoverVersionIncrement) **MUST** be a unique value, not used by any
+      # other cluster.
+      #
+      # WARNING: once the Cadence cluster group is launched, you **MUST** only
+      # add Cadence clusters to the clusterInformation list and **MUST NOT**
+      # remove any Cadence cluster, although you **MAY** disable listed
+      # clusters.
+      #
+      # WARNING: you **MUST** list the Cadence clusters of a Cadence cluster
+      # group in the same order in each configuration to ensure the
+      # initialFailoverVersions are synchronized.
+      clusterInformation:
+        - name: cluster-0
+          # enabled defines whether the Cadence cluster is enabled.
+          enabled: true
+          # rpcAddress defines the address (host:port, host can be a DNS name)
+          # of the Cadence frontend remote service to use in a Cadence cluster.
+          #
+          # This is defaulted to the in-cluster Cadence frontend service, using
+          # the chart configured release name and frontend port, but can be
+          # manually overridden here if necessary.
+          # rpcAddress: cadence-frontend:7933
+        - name: cluster-1
+          enabled: true
+
     logLevel: "debug,info"
 
     # IMPORTANT: This value cannot be changed, once it's set.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | resolves #1274
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added Cadence clusterMetadata configuration.
Extended the `values.yaml` with a corresponding configuration section in order to be able to overwrite the default configuration.
Also let the old default configuration be used whenever the `values.yaml.server.config.clusterMetadata` section is not defined to be backward compatible with old `values.yaml` files.

Related to #1275, I also fixed the legacy `clusterMetadata` default values, it was broken since 0.18, because of the conditional set on a raw string of embedded template which always resolved to true.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It was requested in #1274.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested with the regular chart update test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)
