### PR TITLE
Backported Cadence clusterMetadata default values fix to 0.19

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.19.0
+version: 0.19.1
 appVersion: 0.20.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -148,24 +148,13 @@ data:
       enableGlobalDomain: {{ `{{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}` }}
       failoverVersionIncrement: 10
       masterClusterName: "primary"
-    {{- if `{{ .Env.IS_NOT_PRIMARY }}` }}
-      currentClusterName: "secondary"
-    {{- else }}
       currentClusterName: "primary"
-    {{- end }}
       clusterInformation:
         primary:
           enabled: true
           initialFailoverVersion: 0
           rpcName: "cadence-frontend"
           rpcAddress: {{ `{{ default .Env.PRIMARY_SEEDS "cadence" }}` }}:7933
-      {{- if `{{ .Env.ENABLE_GLOBAL_DOMAIN }}` }}
-        secondary:
-            enabled: true
-            initialFailoverVersion: 2
-            rpcName: "cadence-frontend"
-            rpcAddress: {{ `{{ default .Env.SECONDARY_SEEDS "cadence-secondary" }}` }}:7933
-      {{- end }}
 
     dcRedirectionPolicy:
       policy: {{ `{{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}` }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related to #1275 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Backported Cadence clusterMetadata default values fix to 0.19.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It was broken since 0.18.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This is a fix backport onto the 0.19 minor version.

Configurability of `clusterMetadata` and `clusterInformation` including setups with multiple clusters will be supported in chart 0.21 (#1278).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
