### PR TITLE
Fixed Cadence default config to use single cluster

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.21.0
+version: 0.21.1
 appVersion: 0.21.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -138,8 +138,8 @@ server:
           # the chart configured release name and frontend port, but can be
           # manually overridden here if necessary.
           # rpcAddress: cadence-frontend:7933
-        - name: cluster-1
-          enabled: true
+        # - name: cluster-1
+        #   enabled: true
 
     logLevel: "debug,info"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed Cadence default config to use single cluster.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because the default should be the single cluster setup.
It probably creeped in with another change while I was testing.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)
