### PR TITLE
Fix additional labels for servicemonitor

### DIFF
--- a/cadence/templates/server-service-monitor.yaml
+++ b/cadence/templates/server-service-monitor.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
-    {{- range $key, $value := $.Values.server.metrics.serviceMonitor.additionalLabels }}
+    {{- range $key, $value := (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/cadence/templates/server-service-monitor.yaml
+++ b/cadence/templates/server-service-monitor.yaml
@@ -13,8 +13,8 @@ metadata:
     app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
     app.kubernetes.io/component: {{ $service }}
     app.kubernetes.io/part-of: {{ $.Chart.Name }}
-    {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
-    {{- toYaml . | indent 4 }}
+    {{- range $key, $value := $.Values.server.metrics.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1291
| License         | Apache 2.0


### What's in this PR?
When deploying cadence Helm chart with server.meitrics.serviceMonitor.additionalLabels in values.yaml, the chart fails unless the value is a string, in which case the label is not created.

### Why?
Edit values.yaml and add additionalLabels as map value(s).

```yaml
server:
  metrics:
    serviceMonitor:
      enabled: true
      additionalLabels:
        release: "promethues"
```
and install the helm charts would get the error：

```shell
Error: YAML parse error on cadence/templates/server-service-monitor.yaml: error converting YAML to JSON: yaml: line 12: mapping values are not allowed in this context
```

Expected behavior was the additionalLables should be created in the servicemonitor.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
