### PR TITLE
Support  to modify the log level key name in the cadence

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.22.0
+version: 0.22.1
 appVersion: 0.22.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -14,7 +14,7 @@ data:
     log:
       stdout: true
       level: {{ .Values.server.config.logLevel | quote }}
-      levelKey: "level"
+      levelKey: {{ .Values.server.config.levelKey | quote }}
 
     persistence:
       defaultStore: default

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -142,6 +142,7 @@ server:
         #   enabled: true
 
     logLevel: "debug,info"
+    levelKey: "level"
 
     # IMPORTANT: This value cannot be changed, once it's set.
     numHistoryShards: 512


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?

Support  to modify the log level key name in the cadence

### Why?
The log level key was used to identify which field in the log JSON was represented the log level and regard the log as ERROR level when the log level key was not found, so we want to have a way to change log level key(default was "level").


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

