### PR TITLE
Upgrade Thanos dashboards to a forked version where job patterns are more generic

### DIFF
--- a/grafana-operator/Chart.yaml
+++ b/grafana-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: grafana-operator
 description: Grafana-operator Helm chart for Kubernetes
 
-version: 0.3.12
+version: 0.3.13
 
 appVersion: master
 

--- a/grafana-operator/hack/sync_grafana_dashboards.py
+++ b/grafana-operator/hack/sync_grafana_dashboards.py
@@ -47,56 +47,56 @@ charts = [
         'prefix': ''
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/bucket-replicate.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/bucket_replicate.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/compact.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/compact.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/overview.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/overview.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/query.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/query.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/receive.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/receive.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/rule.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/rule.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/sidecar.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/sidecar.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',
         'prefix': 'thanos_'
     },
     {
-        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/store.json',
+        'source': 'https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/store.json',
         'destination': '../templates/dashboards',
         'type': 'json',
         'min_kubernetes': '1.14.0-0',

--- a/grafana-operator/templates/dashboards/thanos_bucket_replicate.yaml
+++ b/grafana-operator/templates/dashboards/thanos_bucket_replicate.yaml
@@ -1,23 +1,23 @@
 {{- /*
-Generated from 'bucket-replicate' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/bucket-replicate.json
+Generated from 'bucket_replicate' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/bucket_replicate.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
 This script is based on: https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack great works thanks!
 
 */ -}}
-{{- if and .Values.defaultDashboards.enabled .Values.defaultDashboards.thanos.bucket_replicate.enabled }}
+{{- if and .Values.defaultDashboards.enabled .enabled }}
 
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name: {{ printf "%s-%s" (include "grafana-operator.fullname" $) "bucket-replicate" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "grafana-operator.fullname" $) "bucket_replicate" | trunc 63 | trimSuffix "-" }}
   labels: {{- include "grafana-operator.labels" . | nindent 8 }}
 spec:
-  name: {{ printf "%s-%s" (include "grafana-operator.fullname" $) "bucket-replicate" | trunc 63 | trimSuffix "-" }}
-  {{- if .Values.defaultDashboards.thanos.bucket_replicate.plugins }}
+  name: {{ printf "%s-%s" (include "grafana-operator.fullname" $) "bucket_replicate" | trunc 63 | trimSuffix "-" }}
+  {{- if .plugins }}
   plugins:
-    {{- toYaml .Values.defaultDashboards.thanos.bucket_replicate.plugins | nindent 8 }}
+    {{- toYaml .plugins | nindent 8 }}
   {{- end }}
   json: >-
     {
@@ -69,11 +69,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_replicate_replication_runs_total{result=\"error\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) / sum(rate(thanos_replicate_replication_runs_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_replicate_replication_runs_total{result=\"error\", job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_replicate_replication_runs_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -146,7 +145,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_replicate_replication_runs_total{result=\"error\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) by (result)",
+                                "expr": "sum by (job, result) (rate(thanos_replicate_replication_runs_total{result=\"error\", job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}result{{`}}`}}",
@@ -216,34 +215,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_replicate_replication_run_duration_seconds_bucket{result=\"success\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_replicate_replication_run_duration_seconds_bucket{result=\"success\",  job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_replicate_replication_run_duration_seconds_sum{result=\"success\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) by (job) * 1 / sum(rate(thanos_replicate_replication_run_duration_seconds_count{result=\"success\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_replicate_replication_run_duration_seconds_bucket{result=\"success\",  job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_replicate_replication_run_duration_seconds_bucket{result=\"success\", namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_replicate_replication_run_duration_seconds_bucket{result=\"success\",  job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -327,15 +351,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_replicate_origin_iterations_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
-                                "format": "time_series",
-                                "intervalFactor": 2,
-                                "legendFormat": "iterations",
-                                "legendLink": null,
-                                "step": 10
-                            },
-                            {
-                                "expr": "sum(rate(thanos_replicate_origin_meta_loads_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(blocks_meta_synced{state=\"loaded\", job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "meta loads",
@@ -343,7 +359,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_replicate_origin_partial_meta_reads_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(blocks_meta_synced{state=\"failed\", job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "partial meta reads",
@@ -351,7 +367,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_replicate_blocks_already_replicated_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_replicate_blocks_already_replicated_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "already replicated blocks",
@@ -359,7 +375,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_replicate_blocks_replicated_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_replicate_blocks_replicated_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "replicated blocks",
@@ -367,7 +383,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_replicate_objects_replicated_total{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_replicate_objects_replicated_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "replicated objects",
@@ -429,8 +445,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -440,49 +456,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye--bucket-replicate.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye--bucket-replicate.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -498,6 +471,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*bucket.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },
@@ -532,7 +528,7 @@ spec:
         },
         "timezone": "UTC",
         "title": "Thanos / BucketReplicate",
-        "uid": "65ffb86cd2688b9e4db4d1ea231a5a9a",
+        "uid": "49f644ecf8e31dd1a5084ae2a5f10e80",
         "version": 0
     }
 {{- end }}

--- a/grafana-operator/templates/dashboards/thanos_compact.yaml
+++ b/grafana-operator/templates/dashboards/thanos_compact.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'compact' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/compact.json
+Generated from 'compact' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/compact.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -68,7 +68,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
+                                "expr": "sum by (job, group) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "compaction {{`{{`}}job{{`}}`}} {{`{{`}}group{{`}}`}}",
@@ -147,11 +147,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -236,7 +235,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, group)",
+                                "expr": "sum by (job, group) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "downsample {{`{{`}}job{{`}}`}} {{`{{`}}group{{`}}`}}",
@@ -315,11 +314,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_downsample_failed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_downsample_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_compact_downsample_failed_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -404,7 +402,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "garbage collection {{`{{`}}job{{`}}`}}",
@@ -483,11 +481,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_garbage_collection_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_compact_garbage_collection_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -553,34 +550,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_compact_garbage_collection_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_compact_garbage_collection_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -638,7 +660,7 @@ spec:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
+                        "description": "Shows deletion rate of blocks already marked for deletion.",
                         "fill": 10,
                         "id": 8,
                         "legend": {
@@ -665,7 +687,250 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_compact_blocks_cleaned_total{job=~\"$job\"}[$interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Blocks cleanup {{`{{`}}job{{`}}`}}",
+                                "legendLink": null,
+                                "step": 10
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Deletion Rate",
+                        "tooltip": {
+                            "shared": false,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "description": "Shows deletion failures rate of blocks already marked for deletion.",
+                        "fill": 1,
+                        "id": 9,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by (job) (rate(thanos_compact_block_cleanup_failures_total{job=~\"$job\"}[$interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Blocks cleanup failures {{`{{`}}job{{`}}`}}",
+                                "legendLink": null,
+                                "step": 10
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Deletion Error Rate",
+                        "tooltip": {
+                            "shared": false,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "description": "Shows rate at which blocks are marked for deletion (from GC and retention policy).",
+                        "fill": 1,
+                        "id": 10,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by (job) (rate(thanos_compact_blocks_marked_for_deletion_total{job=~\"$job\"}[$interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Blocks marked {{`{{`}}job{{`}}`}}",
+                                "legendLink": null,
+                                "step": 10
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Marking Rate",
+                        "tooltip": {
+                            "shared": false,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Blocks deletion",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
+                        "fill": 10,
+                        "id": 11,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 0,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 4,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "sync {{`{{`}}job{{`}}`}}",
@@ -719,7 +984,7 @@ spec:
                         "datasource": "$datasource",
                         "description": "Shows ratio of errors compared to the total number of executed meta file sync.",
                         "fill": 10,
-                        "id": 9,
+                        "id": 12,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -744,11 +1009,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_blocks_meta_sync_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_blocks_meta_sync_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -796,7 +1060,7 @@ spec:
                         "datasource": "$datasource",
                         "description": "Shows how long has it taken to execute meta file sync, in quantiles.",
                         "fill": 1,
-                        "id": 10,
+                        "id": 13,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -814,34 +1078,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_blocks_meta_sync_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_blocks_meta_sync_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -901,7 +1190,7 @@ spec:
                         "datasource": "$datasource",
                         "description": "Shows rate of execution for operations against the bucket.",
                         "fill": 10,
-                        "id": 11,
+                        "id": 14,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -926,7 +1215,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}operation{{`}}`}}",
@@ -980,7 +1269,7 @@ spec:
                         "datasource": "$datasource",
                         "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
                         "fill": 10,
-                        "id": 12,
+                        "id": 15,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1005,11 +1294,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1057,7 +1345,7 @@ spec:
                         "datasource": "$datasource",
                         "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
                         "fill": 1,
-                        "id": 13,
+                        "id": 16,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1075,34 +1363,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1161,7 +1474,7 @@ spec:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 1,
-                        "id": 14,
+                        "id": 17,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1186,50 +1499,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1277,7 +1590,7 @@ spec:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 1,
-                        "id": 15,
+                        "id": 18,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1302,10 +1615,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1353,7 +1666,7 @@ spec:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 1,
-                        "id": 16,
+                        "id": 19,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -1378,10 +1691,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1440,8 +1753,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -1451,72 +1764,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-compact.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-compact.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-compact.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -1532,6 +1779,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*compact.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },

--- a/grafana-operator/templates/dashboards/thanos_overview.yaml
+++ b/grafana-operator/templates/dashboards/thanos_overview.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'overview' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/overview.json
+Generated from 'overview' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/overview.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -36,15 +36,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -77,18 +69,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -171,11 +183,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{handler=\"query\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{handler=\"query\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -256,7 +267,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -330,15 +341,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -371,18 +374,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query_range\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -465,11 +488,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query_range\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query_range\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{handler=\"query_range\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -550,7 +572,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"one-eye-query.*\",handler=\"query_range\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query_range\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -624,26 +646,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -676,18 +679,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"one-eye-store.*\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -770,11 +845,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"one-eye-store.*\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"one-eye-store.*\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -855,7 +929,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",namespace=\"$namespace\",job=~\"one-eye-store.*\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -929,26 +1003,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -981,18 +1036,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"one-eye-sidecar.*\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1075,11 +1202,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"one-eye-sidecar.*\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"one-eye-sidecar.*\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1160,7 +1286,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",namespace=\"$namespace\",job=~\"one-eye-sidecar.*\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -1234,15 +1360,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -1275,18 +1393,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"one-eye-receive.*\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -1369,11 +1507,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"one-eye-receive.*\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"one-eye-receive.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{handler=\"receive\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1454,7 +1591,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{handler=\"receive\",namespace=\"$namespace\",job=~\"one-eye-receive.*\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"receive\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -1568,7 +1705,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"one-eye-rule.*\"}[$interval])) by (job, alertmanager)",
+                                "expr": "sum by (job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}alertmanager{{`}}`}}",
@@ -1655,11 +1792,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"one-eye-rule.*\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"one-eye-rule.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_alert_sender_errors_total{}[$interval])) / sum by (job) (rate(thanos_alert_sender_alerts_sent_total{}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1740,7 +1876,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"one-eye-rule.*\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} P99",
@@ -1854,7 +1990,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"one-eye-compact.*\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_compact_group_compactions_total{}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "compaction {{`{{`}}job{{`}}`}}",
@@ -1941,11 +2077,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\",job=~\"one-eye-compact.*\"}[$interval])) / sum(rate(thanos_compact_group_compactions_total{namespace=\"$namespace\",job=~\"one-eye-compact.*\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -2003,8 +2138,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -2014,26 +2149,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,

--- a/grafana-operator/templates/dashboards/thanos_query.yaml
+++ b/grafana-operator/templates/dashboards/thanos_query.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'query' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/query.json
+Generated from 'query' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/query.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -36,15 +36,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -69,18 +61,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -155,11 +167,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -225,34 +236,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval])) by (job) * 1 / sum(rate(http_request_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",handler=\"query\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -305,15 +341,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -338,18 +366,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -424,11 +472,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -494,34 +541,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(http_request_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval])) by (job) * 1 / sum(rate(http_request_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",handler=\"query_range\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -574,26 +646,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -618,18 +671,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_client_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -704,11 +829,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_client_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -774,34 +898,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_client_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_client_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -854,26 +1003,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -898,18 +1028,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_client_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -984,11 +1186,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_client_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1054,34 +1255,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_client_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_client_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1166,7 +1392,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "lookups {{`{{`}}job{{`}}`}}",
@@ -1245,11 +1471,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_querier_store_apis_dns_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_querier_store_apis_dns_lookups_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1333,50 +1558,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1449,10 +1674,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1525,10 +1750,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1587,8 +1812,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -1598,72 +1823,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-query.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-query.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-query.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -1679,6 +1838,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*query.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },

--- a/grafana-operator/templates/dashboards/thanos_receive.yaml
+++ b/grafana-operator/templates/dashboards/thanos_receive.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'receive' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/receive.json
+Generated from 'receive' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/receive.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -36,15 +36,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "1xx": "#EAB839",
-                            "2xx": "#7EB26D",
-                            "3xx": "#6ED0E0",
-                            "4xx": "#EF843C",
-                            "5xx": "#E24D42",
-                            "error": "#E24D42",
-                            "success": "#7EB26D"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -69,18 +61,38 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/1../",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/2../",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/3../",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/4../",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/5../",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(label_replace(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval]),\"status_code\", \"${1}xx\", \"code\", \"([0-9])..\")) by (job, handler, status_code)",
+                                "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"receive\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}status_code{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}handler{{`}}`}} {{`{{`}}code{{`}}`}}",
                                 "step": 10
                             }
                         ],
@@ -155,11 +167,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\",code=~\"5..\"}[$interval])) / sum(rate(http_requests_total{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"receive\",code=~\"5..\"}[$interval])) / sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"receive\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -225,34 +236,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(http_request_duration_seconds_sum{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(http_request_duration_seconds_count{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{handler=\"receive\",namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -337,7 +373,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_receive_replications_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "all {{`{{`}}job{{`}}`}}",
@@ -416,11 +452,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\",result=\"error\"}[$interval])) / sum(rate(thanos_receive_replications_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_receive_replications_total{job=~\"$job\", result=\"error\"}[$interval])) / sum by (job) (rate(thanos_receive_replications_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -505,7 +540,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_receive_forward_requests_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_receive_forward_requests_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "all {{`{{`}}job{{`}}`}}",
@@ -584,11 +619,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_receive_forward_requests_total{namespace=\"$namespace\",job=~\"$job\",result=\"error\"}[$interval])) / sum(rate(thanos_receive_forward_requests_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_receive_forward_requests_total{job=~\"$job\", result=\"error\"}[$interval])) / sum by (job) (rate(thanos_receive_forward_requests_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -641,26 +675,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -685,18 +700,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -771,11 +858,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -841,34 +927,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method=\"RemoteWrite\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -921,26 +1032,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -965,18 +1057,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1051,11 +1215,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1121,34 +1284,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\",grpc_method!=\"RemoteWrite\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1201,26 +1389,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -1245,18 +1414,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1331,11 +1572,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1401,34 +1641,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1525,6 +1790,7 @@ spec:
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                                 "decimals": 2,
                                 "link": false,
+                                "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
                                 "linkUrl": "",
                                 "pattern": "Value",
@@ -1546,7 +1812,7 @@ spec:
                         ],
                         "targets": [
                             {
-                                "expr": "time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace=\"$namespace\",job=~\"$job\"}) by (job, bucket)",
+                                "expr": "time() - max by (job, bucket) (thanos_objstore_bucket_last_successful_upload_time{job=~\"$job\"})",
                                 "format": "table",
                                 "instant": true,
                                 "intervalFactor": 2,
@@ -1636,50 +1902,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1752,10 +2018,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1828,10 +2094,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1890,8 +2156,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -1901,72 +2167,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-receive.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-receive.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-receive.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -1982,6 +2182,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*receive.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },

--- a/grafana-operator/templates/dashboards/thanos_rule.yaml
+++ b/grafana-operator/templates/dashboards/thanos_rule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'rule' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/rule.json
+Generated from 'rule' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/rule.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -67,7 +67,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (strategy) (rate(prometheus_rule_evaluations_total{namespace=\"$namespace\",job=\"$job\"}[$interval]))\n",
+                                "expr": "sum by (job, strategy) (rate(prometheus_rule_evaluations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}} strategy {{`}}`}}",
@@ -143,7 +143,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace=\"$namespace\",job=\"$job\"}[$interval]))\n",
+                                "expr": "sum by (job, strategy) (increase(prometheus_rule_group_iterations_missed_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}} strategy {{`}}`}}",
@@ -219,7 +219,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "(\n  max by(rule_group) (prometheus_rule_group_last_duration_seconds{namespace=\"$namespace\",job=\"$job\"})\n  >\n  sum by(rule_group) (prometheus_rule_group_interval_seconds{namespace=\"$namespace\",job=\"$job\"})\n)\n",
+                                "expr": "(\n  max by(job, rule_group) (prometheus_rule_group_last_duration_seconds{job=~\"$job\"})\n  >\n  sum by(job, rule_group) (prometheus_rule_group_interval_seconds{job=~\"$job\"})\n)\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}} rule_group {{`}}`}}",
@@ -308,7 +308,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
+                                "expr": "sum by (job, alertmanager) (rate(thanos_alert_sender_alerts_dropped_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}alertmanager{{`}}`}}",
@@ -385,7 +385,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, alertmanager)",
+                                "expr": "sum by (job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}alertmanager{{`}}`}}",
@@ -464,11 +464,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_sender_errors_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_alert_sender_errors_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_alert_sender_alerts_sent_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -534,34 +533,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 3,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_alert_sender_latency_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_alert_sender_latency_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -646,10 +670,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, pod)",
+                                "expr": "sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}job{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -725,11 +749,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_alert_queue_alerts_pushed_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_alert_queue_alerts_dropped_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_alert_queue_alerts_pushed_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -782,26 +805,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -826,18 +830,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -912,11 +988,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -982,34 +1057,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1062,26 +1162,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -1106,18 +1187,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1192,11 +1345,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1262,34 +1414,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1373,50 +1550,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1489,10 +1666,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1565,10 +1742,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1627,8 +1804,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -1638,72 +1815,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-rule.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-rule.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-rule.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -1719,6 +1830,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*rule.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },

--- a/grafana-operator/templates/dashboards/thanos_sidecar.yaml
+++ b/grafana-operator/templates/dashboards/thanos_sidecar.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'sidecar' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/sidecar.json
+Generated from 'sidecar' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/sidecar.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -36,26 +36,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -80,18 +61,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -166,11 +219,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -236,34 +288,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -316,26 +393,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -360,18 +418,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -445,11 +575,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -515,34 +644,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -639,6 +793,7 @@ spec:
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
                                 "decimals": 2,
                                 "link": false,
+                                "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
                                 "linkUrl": "",
                                 "pattern": "Value",
@@ -660,7 +815,7 @@ spec:
                         ],
                         "targets": [
                             {
-                                "expr": "time() - max(thanos_objstore_bucket_last_successful_upload_time{namespace=\"$namespace\",job=~\"$job\"}) by (job, bucket)",
+                                "expr": "time() - max by (job, bucket) (thanos_objstore_bucket_last_successful_upload_time{job=~\"$job\"})",
                                 "format": "table",
                                 "instant": true,
                                 "intervalFactor": 2,
@@ -750,7 +905,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}operation{{`}}`}}",
@@ -828,11 +983,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -897,34 +1051,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -1008,50 +1187,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1124,10 +1303,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1200,10 +1379,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -1262,8 +1441,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -1273,72 +1452,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-sidecar.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-sidecar.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-sidecar.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -1354,6 +1467,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*sidecar.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },

--- a/grafana-operator/templates/dashboards/thanos_store.yaml
+++ b/grafana-operator/templates/dashboards/thanos_store.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'store' from https://raw.githubusercontent.com/banzaicloud/thanos-operator/master/dashboards/store.json
+Generated from 'store' from https://raw.githubusercontent.com/banzaicloud/thanos/mixin-job-pattern/examples/dashboards/store.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/banzaicloud/banzai-charts/tree/master/grafana-operator/hack
 
@@ -36,26 +36,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -80,18 +61,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -166,11 +219,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -236,34 +288,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"unary\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -316,26 +393,7 @@ spec:
                 "height": "250px",
                 "panels": [
                     {
-                        "aliasColors": {
-                            "Aborted": "#EAB839",
-                            "AlreadyExists": "#7EB26D",
-                            "Canceled": "#E24D42",
-                            "DataLoss": "#E24D42",
-                            "DeadlineExceeded": "#E24D42",
-                            "FailedPrecondition": "#6ED0E0",
-                            "Internal": "#E24D42",
-                            "InvalidArgument": "#EF843C",
-                            "NotFound": "#EF843C",
-                            "OK": "#7EB26D",
-                            "OutOfRange": "#E24D42",
-                            "PermissionDenied": "#EF843C",
-                            "ResourceExhausted": "#E24D42",
-                            "Unauthenticated": "#EF843C",
-                            "Unavailable": "#E24D42",
-                            "Unimplemented": "#6ED0E0",
-                            "Unknown": "#E24D42",
-                            "error": "#E24D42"
-                        },
+                        "aliasColors": {},
                         "bars": false,
                         "dashLength": 10,
                         "dashes": false,
@@ -360,18 +418,90 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "/Aborted/",
+                                "color": "#EAB839"
+                            },
+                            {
+                                "alias": "/AlreadyExists/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "/FailedPrecondition/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/Unimplemented/",
+                                "color": "#E0B400"
+                            },
+                            {
+                                "alias": "/InvalidArgument/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/NotFound/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/PermissionDenied/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Unauthenticated/",
+                                "color": "#1F60C4"
+                            },
+                            {
+                                "alias": "/Canceled/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DataLoss/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/DeadlineExceeded/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Internal/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OutOfRange/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/ResourceExhausted/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unavailable/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/Unknown/",
+                                "color": "#C4162A"
+                            },
+                            {
+                                "alias": "/OK/",
+                                "color": "#37872D"
+                            },
+                            {
+                                "alias": "error",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, grpc_code)",
+                                "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}} {{`{{`}}grpc_code{{`}}`}}",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -446,11 +576,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) / sum(rate(grpc_server_started_total{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval]))",
+                                "expr": "sum by (job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -516,34 +645,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handling_seconds_sum{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job) * 1\n/\nsum(rate(grpc_server_handling_seconds_count{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job)\n",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\",job=~\"$job\",grpc_type=\"server_stream\"}[$interval])) by (job, grpc_method, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}} {{`{{`}}grpc_method{{`}}`}}",
-                                "legendLink": null,
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -628,7 +782,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}operation{{`}}`}}",
@@ -705,7 +859,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}operation{{`}}`}}",
@@ -782,7 +936,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
@@ -790,7 +944,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation) * 1 / sum(rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                                "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_sum{job=~\"$job\"}[$interval])) * 1  / sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "mean {{`{{`}}job{{`}}`}}",
@@ -798,7 +952,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
@@ -887,7 +1041,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "block loads",
@@ -966,11 +1120,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_bucket_store_block_load_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_block_load_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1043,7 +1196,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, operation)",
+                                "expr": "sum by (job, operation) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "block drops {{`{{`}}job{{`}}`}}",
@@ -1122,11 +1275,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_bucket_store_block_drop_failures_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) / sum(rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\",job=~\"$job\"}[$interval]))",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_block_drop_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "error",
-                                "refId": "A",
                                 "step": 10
                             }
                         ],
@@ -1211,7 +1363,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_store_index_cache_requests_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, item_type)",
+                                "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_requests_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}item_type{{`}}`}}",
@@ -1288,7 +1440,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_store_index_cache_hits_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, item_type)",
+                                "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_hits_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}item_type{{`}}`}}",
@@ -1365,7 +1517,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_store_index_cache_items_added_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, item_type)",
+                                "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_added_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}item_type{{`}}`}}",
@@ -1442,7 +1594,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(thanos_store_index_cache_items_evicted_total{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, item_type)",
+                                "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_evicted_total{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}job{{`}}`}} {{`{{`}}item_type{{`}}`}}",
@@ -1531,7 +1683,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P99",
@@ -1539,7 +1691,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) / sum(rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "mean",
@@ -1547,7 +1699,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le))",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$interval])))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P50",
@@ -1635,7 +1787,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.99\"}",
+                                "expr": "thanos_bucket_store_series_blocks_queried{job=~\"$job\", quantile=\"0.99\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P99",
@@ -1643,7 +1795,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_blocks_queried_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_blocks_queried_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_series_blocks_queried_sum{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_series_blocks_queried_count{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "mean {{`{{`}}job{{`}}`}}",
@@ -1651,7 +1803,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.50\"}",
+                                "expr": "thanos_bucket_store_series_blocks_queried{job=~\"$job\", quantile=\"0.50\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P50",
@@ -1728,7 +1880,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.99\"}",
+                                "expr": "thanos_bucket_store_series_data_fetched{job=~\"$job\", quantile=\"0.99\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P99",
@@ -1736,7 +1888,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_data_fetched_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_data_fetched_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_series_data_fetched_sum{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_series_data_fetched_count{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "mean {{`{{`}}job{{`}}`}}",
@@ -1744,7 +1896,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.50\"}",
+                                "expr": "thanos_bucket_store_series_data_fetched{job=~\"$job\", quantile=\"0.50\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P50",
@@ -1820,7 +1972,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.99\"}",
+                                "expr": "thanos_bucket_store_series_result_series{job=~\"$job\",quantile=\"0.99\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P99",
@@ -1828,7 +1980,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_result_series_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) / sum(rate(thanos_bucket_store_series_result_series_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "sum by (job) (rate(thanos_bucket_store_series_result_series_sum{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_series_result_series_count{job=~\"$job\"}[$interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "mean {{`{{`}}job{{`}}`}}",
@@ -1836,7 +1988,7 @@ spec:
                                 "step": 10
                             },
                             {
-                                "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\",job=~\"$job\",quantile=\"0.50\"}",
+                                "expr": "thanos_bucket_store_series_result_series{job=~\"$job\",quantile=\"0.50\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "P50",
@@ -1918,34 +2070,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_get_all_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_bucket_store_series_get_all_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -2011,34 +2188,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_merge_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_bucket_store_series_merge_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -2104,34 +2306,59 @@ spec:
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "p99",
+                                "color": "#FA6400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p90",
+                                "color": "#E0B400",
+                                "fill": 1,
+                                "fillGradient": 1
+                            },
+                            {
+                                "alias": "p50",
+                                "color": "#37872D",
+                                "fill": 10,
+                                "fillGradient": 0
+                            }
+                        ],
                         "spaceLength": 10,
                         "span": 4,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P99 {{`{{`}}job{{`}}`}}",
-                                "refId": "A",
+                                "legendFormat": "p50 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "sum(rate(thanos_bucket_store_series_gate_duration_seconds_sum{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job) * 1 / sum(rate(thanos_bucket_store_series_gate_duration_seconds_count{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job)",
+                                "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "mean {{`{{`}}job{{`}}`}}",
-                                "refId": "B",
+                                "legendFormat": "p90 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             },
                             {
-                                "expr": "histogram_quantile(0.50, sum(rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[$interval])) by (job, le)) * 1",
+                                "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "P50 {{`{{`}}job{{`}}`}}",
-                                "refId": "C",
+                                "legendFormat": "p99 {{`{{`}}job{{`}}`}}",
+                                "logBase": 10,
+                                "max": null,
+                                "min": null,
                                 "step": 10
                             }
                         ],
@@ -2215,50 +2442,50 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate all {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate all {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}[30s])",
+                                "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "alloc rate heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "alloc rate heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse stack {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse heap {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             },
                             {
-                                "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "inuse heap {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "inuse stack {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -2331,10 +2558,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{namespace=\"$namespace\",job=~\"$job\"}",
+                                "expr": "go_goroutines{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -2407,10 +2634,10 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=~\"$job\",kubernetes_pod_name=~\"$pod\"}",
+                                "expr": "go_gc_duration_seconds{job=~\"$job\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}pod{{`}}`}}",
+                                "legendFormat": "{{`{{`}}quantile{{`}}`}} {{`{{`}}instance{{`}}`}}",
                                 "legendLink": null,
                                 "step": 10
                             }
@@ -2469,8 +2696,8 @@ spec:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": null,
@@ -2480,72 +2707,6 @@ spec:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
-                },
-                {
-                    "allValue": null,
-                    "current": {},
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": "namespace",
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{}, namespace)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": "one-eye-store.*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "job",
-                    "multi": false,
-                    "name": "job",
-                    "options": [],
-                    "query": "label_values(up{namespace=\"$namespace\",job=~\"one-eye-store.*\"}, job)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".*",
-                    "current": {
-                        "text": "all",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
-                    "label": "pod",
-                    "multi": false,
-                    "name": "pod",
-                    "options": [],
-                    "query": "label_values(kube_pod_info{namespace=\"$namespace\",created_by_name=~\"one-eye-store.*\"}, pod)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
                 },
                 {
                     "auto": true,
@@ -2561,6 +2722,29 @@ spec:
                     "query": "5m,10m,30m,1h,6h,12h",
                     "refresh": 2,
                     "type": "interval"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": "job",
+                    "multi": false,
+                    "name": "job",
+                    "options": [],
+                    "query": "label_values(up{job=~\".*store.*\"}, job)",
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 2,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Regenerate Thanos dashboards based on https://github.com/banzaicloud/thanos/tree/mixin-job-pattern


### Why?
To make the dashboards useful for installations where the resources names does not contain the thanos prefix.

