### PR TITLE
Prepared Cadence chart release 0.22.0 with server 0.22.3

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
 version: 0.21.3
-appVersion: 0.21.3
+appVersion: 0.22.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.21.3
+version: 0.22.0
 appVersion: 0.22.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.21.0+
+- Cadence 0.22.0+
 
 
 ## Installing the Chart
@@ -328,7 +328,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.21.3`              |
+| `server.image.tag`                                | Server image tag                                      | `0.22.3`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -365,7 +365,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.enabled`                                     | Enable WebUI service                                  | `true`                |
 | `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
-| `web.image.tag`                                   | WebUI image tag                                       | `3.28.4`              |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.28.7`              |
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
 | `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -23,7 +23,8 @@ data:
       datastores:
         default:
           {{- if eq (include "cadence.persistence.driver" (list . "default")) "cassandra" }}
-          cassandra:
+          nosql:
+            pluginName: cassandra
             hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "default") }}
             port: {{ include "cadence.persistence.cassandra.port" (list . "default") }}
             password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
@@ -45,7 +46,8 @@ data:
           {{- end }}
         visibility:
           {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "cassandra" }}
-          cassandra:
+          nosql:
+            pluginName: cassandra
             hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "visibility") }}
             port: {{ include "cadence.persistence.cassandra.port" (list . "visibility") }}
             password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -87,6 +87,10 @@ spec:
               value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
             - name: CASSANDRA_DB_PORT
               value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            {{- if $storeConfig.cassandra.protoVersion }}
+            - name: CASSANDRA_PROTOCOL_VERSION
+              value: {{ $storeConfig.cassandra.protoVersion }}
+            {{- end }}
             - name: CASSANDRA_KEYSPACE
               value: {{ $storeConfig.cassandra.keyspace }}
             {{- if $storeConfig.cassandra.user }}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.21.3
+    tag: 0.22.3
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -159,7 +159,6 @@ server:
           existingSecret: ""
           consistency: One
           # datacenter: "us-east-1a"
-          # maxQPS: 1000
           # maxConns: 2
 
         sql:
@@ -173,7 +172,6 @@ server:
           # maxConns: 20
           # maxIdleConns: 20
           # maxConnLifetime: "1h"
-          # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
 
@@ -189,7 +187,6 @@ server:
           existingSecret: ""
           consistency: One
           # datacenter: "us-east-1a"
-          # maxQPS: 1000
           # maxConns: 2
 
         sql:
@@ -203,7 +200,6 @@ server:
           # maxConns: 20
           # maxIdleConns: 20
           # maxConnLifetime: "1h"
-          # maxQPS: 1000
           # connectAttributes:
             # tx_isolation: "READ-COMMITTED"
 

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -161,6 +161,9 @@ server:
           # datacenter: "us-east-1a"
           # maxConns: 2
 
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
         sql:
           pluginName: "" # mysql
           host: ""
@@ -188,6 +191,9 @@ server:
           consistency: One
           # datacenter: "us-east-1a"
           # maxConns: 2
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
 
         sql:
           pluginName: "" # mysql

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -309,7 +309,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: v3.28.4
+    tag: v3.28.7
     pullPolicy: IfNotPresent
 
   tcheck:

--- a/cadence/values/values.cassandra.yaml
+++ b/cadence/values/values.cassandra.yaml
@@ -10,6 +10,9 @@ server:
           keyspace: "cadence"
           consistency: "One"
 
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
           # Authentication
           # user: ""
           # password: ""
@@ -22,6 +25,9 @@ server:
           port: 9042
           keyspace: "cadence_visibility"
           consistency: "One"
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
 
           # Authentication
           # user: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Prepared Cadence chart 0.22.0 with server 0.22.3.

1. Updated Cadence web 3.28.4->3.28.7
2. Removed obsolete comment about `persistence` `maxQPS`, configuration was dropped from Cadence server in the past.
3. Renamed internal references of Cassandra to NoSQL.
4. Added Cassandra `protoversion` configuration and `CASSANDRA_PROTOCOL_VERSION` environment variable.
5. Updated Cadence server 0.21.3->0.22.3.
6. Bumped Cadence Helm chart version 0.21.2->0.22.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To fully support the latest Cadence minor version 0.22 ([0.22.0](https://github.com/uber/cadence/releases/tag/v0.22.0), [0.22.1](https://github.com/uber/cadence/releases/tag/v0.22.1), [0.22.2](https://github.com/uber/cadence/releases/tag/v0.22.2), [0.22.3](https://github.com/uber/cadence/releases/tag/v0.22.3)).

1. To use the latest available Cadence web version.
2. To clean up the chart.
3. To keep up to date with the upstream configuration practices: https://github.com/uber/cadence/pull/4220.
4. To support Cassandra protocol version as environment variable and chart argument: https://github.com/uber/cadence/pull/4263.
5. To support the latest available Cadence server version.
6. To be able to release a new Cadence Helm chart tag.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

I also checked whether the [`is_cron` field](https://github.com/uber/cadence/pull/4191) or the [feature flags](https://github.com/uber/cadence/pull/4257) would require any chart modification, but as much as I could tell those are internal-only changes to the Cadence server so nothing to change in the chart this time it seems (to be confirmed).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] Wait for a review from the Cadence team to confirm it looks good.
