### PR TITLE
[Cadence] Pull value from secret rather than plaintext in job

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.21.3
+version: 0.21.4
 appVersion: 0.21.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.21.2
+version: 0.21.3
 appVersion: 0.21.3
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -110,7 +110,7 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
+              {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
@@ -165,7 +165,7 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
+              {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -296,7 +296,7 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{ - if .Values.mysql.enabled }}
+              {{- if .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -110,7 +110,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -158,7 +161,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -282,7 +288,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -110,10 +110,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
+              {{- else -}}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end -}}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -161,10 +165,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
+                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
+              {{- else -}}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end -}}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -288,10 +296,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
+                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
+              {{- else -}}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end -}}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}

--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -110,10 +110,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+              {{- if .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
               {{- else -}}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
@@ -165,10 +165,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+              {{- if .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
               {{- else -}}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
@@ -296,10 +296,10 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
-              {{ - if or .Values.cassandra.enabled .Values.mysql.enabled }}
+              {{ - if .Values.mysql.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cadence.persistence.secretName" (list $ $store)  | quote }}
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) | quote }}
                   key: {{ include "cadence.persistence.secretKey" (list $ $store) | quote }}
               {{- else -}}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1301 
| License         | Apache 2.0


### What's in this PR?
This PR has the setup job pull from the secret rather than requiring a plaintext password to be passed in


### Why?
When deploying the chart using an existing secret and setup job, you have to pass in both the secret and the plaintext password for the job.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
