### PR TITLE
updates cadence templates with grpcPort

### DIFF
--- a/cadence/templates/_helpers.tpl
+++ b/cadence/templates/_helpers.tpl
@@ -77,6 +77,10 @@ Source: https://stackoverflow.com/a/52024583/3027614
 7935
 {{- end -}}
 
+{{- define "cadence.worker.internalGRPCPort" -}}
+7839
+{{- end -}}
+
 {{- define "cadence.worker.internalPort" -}}
 7939
 {{- end -}}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -76,6 +76,7 @@ data:
         - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ default .Env.HISTORY_PORT 7934 }}` }}
         - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
         - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.grpcPort | default `{{ default .Env.WORKER_PORT 7839 }}` }}
         - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ default .Env.WORKER_PORT 7939 }}` }}
       maxJoinDuration: 30s
 
@@ -136,6 +137,7 @@ data:
 
       worker:
         rpc:
+          grpcPort: {{ include "cadence.worker.internalGRPCPort" . | default `{{ default .Env.WORKER_GRPC_PORT 7839 }}` }}
           port: {{ include "cadence.worker.internalPort" . | default `{{ default .Env.WORKER_PORT 7939 }}` }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:

--- a/cadence/templates/server-deployment.yaml
+++ b/cadence/templates/server-deployment.yaml
@@ -104,6 +104,9 @@ spec:
                   name: {{ include "cadence.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "cadence.persistence.secretKey" (list $ "visibility") }}
           ports:
+            - name: grpc
+              containerPort: {{ include (printf "cadence.%s.internalGRPCPort" $service) $ }}
+              protocol: TCP
             - name: rpc
               containerPort: {{ include (printf "cadence.%s.internalPort" $service) $ }}
               protocol: TCP

--- a/cadence/templates/server-service.yaml
+++ b/cadence/templates/server-service.yaml
@@ -17,6 +17,10 @@ metadata:
 spec:
   type: {{ .Values.server.frontend.service.type }}
   ports:
+    - port: {{ .Values.server.frontend.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
     - port: {{ .Values.server.frontend.service.port }}
       targetPort: rpc
       protocol: TCP


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in #1305 
| License         | Apache 2.0


### What's in this PR?
adds grpcPort to server-service and server-deployment templates


### Why?
candence clients can now use GRPC for transport which means port 7833 needs be exposed on the cadence-frontend


### Additional context
I have been using this branch in our development k8s environment and everything seems to be working as expected


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### To Do
- [ ] update documents to reflect the availability of GRPC
