### PR TITLE
[thanos] remove default sidecar selector

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.6
+version: 0.4.7
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -329,7 +329,7 @@ timePartioning:
 |Name|Description| Default Value|
 |----|-----------|--------------|
 | sidecar.enabled | NOTE: This is only the service references for the sidecar. | true |
-| sidecar.selector | Pod label selector to match sidecar services on. | `{"app": "prometheus"}` |
+| sidecar.selector | REQUIRED: Pod label selector to match sidecar services on. | |
 
 ## Query Frontend
 

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1085,8 +1085,7 @@ rule:
 sidecar:
   # NOTE: This is only the service references for the sidecar
   enabled: true
-  selector:
-    app: prometheus
+  selector: {}
   # Enable metrics collecting for sidecar service
   metrics:
     # Enable ServiceMonitor https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Removes default sidecar selector as it has changed from `app: prometheus` to `app.kubernetes.io/name: prometheus`. This chart should be able to deal with both variances and the `sidecar.selector` value is now required.

fixes #1261

### Why?
`app` label was removed from prometheus -> https://github.com/prometheus-operator/prometheus-operator/pull/4350.

### Additional context
Tested locally