### PR TITLE
Updated Cadence server 0.22.3 -> 0.23.2, web 3.28.7->3.29.5

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
 version: 0.23.0
-appVersion: 0.23.1
+appVersion: 0.23.2
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
 version: 0.22.1
-appVersion: 0.22.3
+appVersion: 0.23.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.22.1
+version: 0.23.0
 appVersion: 0.23.1
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -365,7 +365,7 @@ Global options overridable per service are marked with an asterisk.
 | `web.enabled`                                     | Enable WebUI service                                  | `true`                |
 | `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
 | `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
-| `web.image.tag`                                   | WebUI image tag                                       | `3.28.7`              |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.29.5`              |
 | `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
 | `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
 | `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -328,7 +328,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.23.1`              |
+| `server.image.tag`                                | Server image tag                                      | `0.23.2`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -19,7 +19,7 @@ This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadenc
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- Cadence 0.22.0+
+- Cadence 0.23.0+
 
 
 ## Installing the Chart
@@ -328,7 +328,7 @@ Global options overridable per service are marked with an asterisk.
 | `nameOverride`                                    | Override name of the application                      | ``                    |
 | `fullnameOverride`                                | Override full name of the application                 | ``                    |
 | `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
-| `server.image.tag`                                | Server image tag                                      | `0.22.3`              |
+| `server.image.tag`                                | Server image tag                                      | `0.23.1`              |
 | `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
 | `server.replicaCount`*                            | Server replica count                                  | `1`                   |
 | `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -154,7 +154,7 @@ data:
         {{- end}}
 
     clusterGroupMetadata:
-      enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomains }}
+      enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomain }}
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
       primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
       currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -179,9 +179,11 @@ data:
     archival:
       status: "disabled"
 
-    dynamicConfigClient:
-      filepath: "/etc/cadence/config/dynamicconfig/config.yaml"
-      pollInterval: {{ .Values.dynamicConfig.pollInterval | default "10s" | quote }}
+    dynamicconfig:
+      client: filebased
+      filebased:
+        filepath: "/etc/cadence/config/dynamicconfig/config.yaml"
+        pollInterval: {{ .Values.dynamicConfig.pollInterval | default "10s" | quote }}
 
   dynamic_config.yaml: |-
     {{- toYaml .Values.dynamicConfig.values | nindent 12 }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -177,7 +177,10 @@ data:
       toDC: ""
 
     archival:
-      status: "disabled"
+      history:
+        status: "disabled"
+      visibility:
+        status: "disabled"
 
     dynamicconfig:
       client: filebased

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -156,7 +156,7 @@ data:
     clusterGroupMetadata:
       enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomains }}
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
-      masterClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
+      primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
       currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}
       clusterInformation:
       {{- $currentClusterName := .Values.server.config.clusterMetadata.currentClusterName }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -153,7 +153,7 @@ data:
             prefix: {{ `{{ default .Env.STATSD_WORKER_PREFIX "cadence.worker" }}` }}
         {{- end}}
 
-    clusterMetadata:
+    clusterGroupMetadata:
       enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomains }}
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
       masterClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -179,10 +179,6 @@ data:
     archival:
       status: "disabled"
 
-    publicClient:
-      {{- $currentClusterInfo := (index .Values.server.config.clusterMetadata.clusterInformation $currentClusterIndex) }}
-      hostPort:  "{{ $currentClusterInfo.rpcAddress | default (printf "%s%s%.0f" $frontendComponentName ":" $serverFrontendServicePort ) }}"
-
     dynamicConfigClient:
       filepath: "/etc/cadence/config/dynamicconfig/config.yaml"
       pollInterval: {{ .Values.dynamicConfig.pollInterval | default "10s" | quote }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -158,7 +158,7 @@ data:
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
       primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
       currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}
-      clusterInformation:
+      clusterGroup:
       {{- $currentClusterName := .Values.server.config.clusterMetadata.currentClusterName }}
       {{- $currentClusterIndex := 0 }}
       {{- $frontendComponentName := (include "cadence.componentname" (list . "frontend")) }}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.22.3
+    tag: 0.23.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -312,7 +312,7 @@ web:
 
   image:
     repository: ubercadence/web
-    tag: v3.28.7
+    tag: v3.29.5
     pullPolicy: IfNotPresent
 
   tcheck:

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.23.1
+    tag: 0.23.2
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Updated Cadence server 0.22.3 -> 0.23.2 and web 3.28.7->3.29.5
- internal-only renamings
    - clusterMetaData -> clusterGroupMetaData
    - masterClusterName -> primaryClusterName
    - clusterInformation -> clusterGroup
- internal-only config changes
    - removed obsolete publicClient config
    - restructured dynamic config 
    - restructured archival config

Also fixed a wrong variable name (`enableGlobalDomains` -> `enableGlobalDomain`).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To support the latest Cadence server and web version.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested with the regular chart update test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)