### PR TITLE
cadence: allow existingSecret to be used in schema setup

### DIFF
--- a/cadence/templates/server-job.yaml
+++ b/cadence/templates/server-job.yaml
@@ -99,7 +99,14 @@ spec:
             {{- end }}
             {{- if $storeConfig.cassandra.password }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
@@ -114,7 +121,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -147,7 +161,14 @@ spec:
             {{- end }}
             {{- if $storeConfig.cassandra.password }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
@@ -162,7 +183,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}
@@ -271,7 +299,14 @@ spec:
             {{- end }}
             {{- if $storeConfig.cassandra.password }}
             - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
             {{- end }}
             {{- end }}
             {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
@@ -286,7 +321,14 @@ spec:
             - name: SQL_USER
               value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
             - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
               value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
             {{- with $storeConfig.sql.connectAttributes }}
             - name: SQL_CONNECT_ATTRIBUTES
               value: {{ include "to-query" . }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR makes cadence schema setup part of the helm chart work when a database password is only stored as a k8s secret via `existingSecret` parameter and not supplied via the `password` parameter. It currently works with schema setup/update being off. (`schema/setup/enabled: false` and `schema/update/enabled: false`. 

### Why?
This PR tries to fix the inconsistency of the chart behaviour. At the moment `existingSecret` would only work alone if the schema setup/update is not enabled. Once it's enabled there is an error reported by helm requiring the password being explicitly given to the chart as a value.

### Additional context
The change was tested on my test k8s setup.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

