### PR TITLE
Update to use registry.k8s.io as k8s.gcr.io is no longer maintained

### DIFF
--- a/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/values.yaml
@@ -45,7 +45,7 @@ sslCertHostPath: /etc/ssl/certs/ca-certificates.crt
 cloudConfigPath: /etc/gce.conf
 
 image:
-  repository: k8s.gcr.io/cluster-autoscaler
+  repository: registry.k8s.io/cluster-autoscaler
   tag: v1.13.1
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | none
| License         | Apache 2.0

### What's in this PR?

All amazon account owners received this email on Friday 3/24/2023.

Amazon Web Services, Inc. <no-reply-aws@amazon.com>
To:AWS GovCloud DEV
Fri 3/24/2023 6:41 AM
[EXTERNAL - CAUTION]

Hello,

Starting April 3, 2023, the Kubernetes project will stop publishing community-owned images (known as community images) to the old image registry `k8s.gcr.io` as announced in the following blog [1]. The `k8s.gcr.io` registry will be frozen. No further images for Kubernetes and related sub-projects will be pushed to the registry. If deemed necessary, the Kubernetes project reserves the right to remove existing community images from the old registry. EKS clusters by default are not dependent on images hosted in the community-owned registry. If your applications are configured to use community-owned images from the legacy registry, you may experience availability issues. You can avoid the issue by updating your application and its dependencies to pull images from the new image registry: `registry.k8s.io`. The new registry contains all the community images and image tags from the old registry.

What is the problem?
On November 28, 2022, the Kubernetes project announced that it would move community images from the `k8s.gcr.io` registry to a new community owned registry: `registry.k8s.io` [2]. This new registry spreads load across multiple cloud providers and regions, functioning like a content delivery network (CDN) for Kubernetes container images. This change reduces the project's reliance on a single entity and provides a faster download experience for users. While the Kubernetes project changed the default to the new image registry, the old registry was still supported. Starting April 3, 2023, the old `k8s.gcr.io` registry will be frozen. The Kubernetes project will stop publishing community images to the old registry. Existing community images in the registry could be removed in the future. Your applications may carry availability risks if your deployments are dependent on images hosted in the old `k8s.gcr.io` registry.

How can you identify if you are impacted?
For step by step guidelines on identifying community images your applications are using from the legacy registry, please refer to image registry redirect documentation [3].

You can also run the new kubectl plugin community-images to identify resources running in your Amazon EKS cluster that are pulling community images from the old image registry. You can find instructions to install and run the community-images plugin here [3].

Alternatively, you can identify pods running in your cluster that are using community images from the old image registry using kubectl to list the images used by pods. You can find the kubectl command here [4].

How can you resolve the issue?
After you have identified the applications that are pulling community images from the old image registry, update your resource definitions for resources such as pods, deployment manifests, and Helm charts. In your resource definitions, change the image registry for container images from `k8s.gcr.io` to `registry.k8s.io`. This will ensure that all subsequent image pull requests are made to the new image registry. The community has set up auto redirects to `registry.k8s.io` for now, but we strongly recommend that you update your resource definitions to use the new registry to future proof your cluster from any instability as per the recommendation from the community [5].

We are continually posting updates and guidelines through our AWS Blog [6], EKS Newsletter [7] and AWS Container from the Couch videos [8] to help you navigate this transition with ease. If you have any questions or concerns, please reach out to AWS Support [9].

[1] https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/#timeline-of-the-changes
[2] https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/
[3] https://kubernetes.io/blog/2023/03/10/image-registry-redirect/#how-can-i-find-which-images-are-using-the-legacy-registry-and-fix-them
[4] https://github.com/kubernetes-sigs/community-images#kubectl-community-images
[5] https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/#what-s-next
[6] https://aws.amazon.com/blogs/containers/changes-to-the-kubernetes-container-image-registry/
[7] https://eks.news/
[8] https://www.youtube.com/shorts/5RvrkLPImGQ
[9] https://aws.amazon.com/support

Sincerely,
Amazon Web Services

### Why?
Updates to use the new registry.k8s.io registry which is still being maintained.

### Additional context
N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

