### PR TITLE
[cadence] - fix relabelling block in Prometheus Operator's ServiceMonitor template

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,5 +1,5 @@
 name: cadence
-version: 0.24.1
+version: 0.24.2
 appVersion: 0.24.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg

--- a/cadence/templates/server-service-monitor.yaml
+++ b/cadence/templates/server-service-monitor.yaml
@@ -22,7 +22,7 @@ spec:
       interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
       {{- with (default $.Values.server.metrics.serviceMonitor.relabellings $serviceValues.metrics.serviceMonitor.relabellings) }}
       metricRelabelings:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   jobLabel: {{ include "cadence.componentname" (list $ $service) }}
   namespaceSelector:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0

### What's in this PR?
Add a missing newline to Prometheus Operator's ServiceMonitor template

### Why?
ServiceMonitor template was producing invalid yaml output, because of missing newline. **This case only pops-up when you try to use relabelling**.  **nindent** is used instead of **indent** to fix the issue. 

### Additional context
The issue can be reproduced and tested with the following commands:
1. first go to **cadence** folder and build Helm deps
```shell
cd cadence
helm dependency build
```
2. Then try to use relabelling:
```shell
#!/bin/bash

helm template \
--set server.metrics.serviceMonitor.enabled=true \
--set server.metrics.serviceMonitor.relabellings[0].sourceLabels={__address__}  \
--set server.metrics.serviceMonitor.relabellings[0].targetLabel=new_label  \
--set server.metrics.serviceMonitor.relabellings[0].replacement=new-value  \
cadence . | grep ServiceMonitor -A20
```

Related resources:
- https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
- https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)