### PR TITLE
[K8s 1.25 support] Migrate PodDisruptionBudget policy/v1beta1 API usage to policy/v1 for Thanos chart

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.17.1
+appVersion: 0.28.1
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.6
+version: 0.4.7
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/bucket-poddisruptionbudget.yaml
+++ b/thanos/templates/bucket-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.bucket.enabled .Values.bucket.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}

--- a/thanos/templates/query-frontend-poddisruptionbudget.yaml
+++ b/thanos/templates/query-frontend-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}

--- a/thanos/templates/query-poddisruptionbudget.yaml
+++ b/thanos/templates/query-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.query.enabled .Values.query.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}


### PR DESCRIPTION
Migrate PodDisruptionBudget policy/v1beta1 API usage to policy/v1 for Kubernetes 1.25 support

Reference: [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125)