### PR TITLE
[K8s 1.25 support] Migrate HorizontalPodAutoScalar to scaling/v2 for Thanos chart 

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.7
+version: 0.4.8
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.queryFrontend.enabled }}
 {{- if .Values.queryFrontend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}

--- a/thanos/templates/query-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-horizontalpodautoscaler.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.query.enabled }}
 {{- if .Values.query.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}


### PR DESCRIPTION
Migrate HorizontalPodAutoScalar to `scaling/v2` for Kubernetes 1.25/1.26 support

Reference: [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125)