### PR TITLE
[K8s 1.25 support] Migrate HorizontalPodAutoScalar to scaling/v2 for Thanos chart

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.8
+version: 0.4.9
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
@@ -23,13 +23,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
 {{- end }}
 {{- with .Values.queryFrontend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/thanos/templates/query-horizontalpodautoscaler.yaml
+++ b/thanos/templates/query-horizontalpodautoscaler.yaml
@@ -23,13 +23,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
 {{- end }}
 {{- with .Values.query.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`autoscaling/v2` no longer supports `targetAverageUtilization` field

