### PR TITLE
Change chart cadence according v1.0.0

### DIFF
--- a/cadence/Chart.yaml
+++ b/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 name: cadence
-version: 0.24.2
-appVersion: 0.24.0
+version: 1.0.0
+appVersion: 1.0.0
 description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
 icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
 apiVersion: v1

--- a/cadence/README.md
+++ b/cadence/README.md
@@ -39,6 +39,9 @@ $ helm install --name my-release --namespace cadence banzaicloud-stable/cadence
 # Helm
 $ helm upgrade [RELEASE_NAME] banzaicloud-stable/cadence
 ```
+### From 1.0.0
+
+It's added in `clustermetadata` the label clusterRedirectionPolicy.policy with default value  "selected-apis-forwarding" to specify the redirection policy between cluster components
 
 ### From 0.20.x (or below) to 0.21.y (or above)
 
@@ -388,6 +391,15 @@ Global options overridable per service are marked with an asterisk.
 | `cassandra.enabled`                               | Install Cassandra cluster                             | `true`                |
 | `cassandra.config.cluster_size`                   | Cassandra cluster node number                         | `1`                   |
 | `mysql.enabled`                                   | Install MySQL                                         | `false`               |
+| `dynamicconfig.client`                            | Dynamic configuration client                          | `filebased`           |
+| `dynamicconfig.configstore.pollInterval`          | ConfigStore polling interval                          | `10s`                 |
+| `dynamicconfig.configstore.updateRetryAttempts`   | Number update retries                                 | `2`                   |
+| `dynamicconfig.configstore.FetchTimeout`          | Fetch timeout                                         | `2s`                  |
+| `dynamicconfig.configstore.UpdateTimeout`         | Configstore update timeout                            | `2s`                  |
+| `dynamicconfig.filebased.filepath`                | Path of the dynamic configuration file                | `config/dynamicconfig/development_es.yaml`                 |
+| `dynamicconfig.filebased.pollInterval`            | Polling interval                                      | `10s`                 |
+| `connectionType.thrift.enabled`                   | Enable connection tchannel                            | `true`                |
+| `connectionType.grpc.enabled`                     | Enable connection grcp                                | `true`                |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -177,7 +177,6 @@ data:
         {{- end}}
 
     clusterGroupMetadata:
-      enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomain }}
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
       primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
       currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}

--- a/cadence/templates/server-configmap.yaml
+++ b/cadence/templates/server-configmap.yaml
@@ -72,20 +72,30 @@ data:
       name: cadence
       bootstrapMode: dns
       bootstrapHosts:
-        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+       {{- if ($.Values.connectionType.thrift.enabled) }}  
         - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
-        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
         - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ default .Env.HISTORY_PORT 7934 }}` }}
-        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
         - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
         - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ default .Env.WORKER_PORT 7939 }}` }}
+      {{- end }}
+      {{- if ($.Values.connectionType.grpc.enabled) }}  
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.grpcPort | default `{{ default .Env.WORKER_PORT 7839 }}` }}
+      {{- end }}
+
       maxJoinDuration: 30s
 
     services:
       frontend:
         rpc:
-          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+        {{- if ($.Values.connectionType.thrift.enabled) }}  
           port: {{ include "cadence.frontend.internalPort" . | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
+        {{- end }}
+        {{- if ($.Values.connectionType.grpc.enabled) }}  
+          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+        {{- end }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -102,8 +112,12 @@ data:
 
       history:
         rpc:
-          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+        {{- if ($.Values.connectionType.thrift.enabled) }}  
           port: {{ include "cadence.history.internalPort" . | default `{{ default .Env.HISTORY_PORT default 7934 }}` }}
+        {{- end }}
+        {{- if ($.Values.connectionType.grpc.enabled) }}  
+          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+        {{- end }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -120,8 +134,12 @@ data:
 
       matching:
         rpc:
-          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+        {{- if ($.Values.connectionType.thrift.enabled) }}  
           port: {{ include "cadence.matching.internalPort" . | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
+        {{- end }}
+        {{- if ($.Values.connectionType.grpc.enabled) }}  
+          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+        {{- end }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -138,7 +156,12 @@ data:
 
       worker:
         rpc:
+        {{- if ($.Values.connectionType.thrift.enabled) }}  
           port: {{ include "cadence.worker.internalPort" . | default `{{ default .Env.WORKER_PORT 7939 }}` }}
+        {{- end }}
+        {{- if ($.Values.connectionType.grpc.enabled) }}  
+          grpcPort: {{ include "cadence.worker.internalGRPCPort" . | default `{{ default .Env.WORKER_GRPC_PORT 7839 }}` }}
+        {{- end }}
           bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
         metrics:
           tags:
@@ -158,6 +181,8 @@ data:
       failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
       primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
       currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}
+      clusterRedirectionPolicy:
+        policy: {{ $.Values.server.config.dcRedirectionPolicy.policy }}
       clusterGroup:
       {{- $currentClusterName := .Values.server.config.clusterMetadata.currentClusterName }}
       {{- $currentClusterIndex := 0 }}
@@ -188,10 +213,15 @@ data:
         status: "disabled"
 
     dynamicconfig:
-      client: filebased
+      client: {{ $.Values.dynamicconfig.client }}
+      configstore:
+        pollInterval: {{ $.Values.dynamicconfig.configstore.pollInterval | default "10s" | quote  }}
+        updateRetryAttempts: {{ $.Values.dynamicconfig.configstore.updateRetryAttempts }}
+        FetchTimeout: {{ $.Values.dynamicconfig.configstore.FetchTimeout | default "2s" | quote }}
+        UpdateTimeout: {{ $.Values.dynamicconfig.configstore.UpdateTimeout | default "2s" | quote }}
       filebased:
-        filepath: "/etc/cadence/config/dynamicconfig/config.yaml"
-        pollInterval: {{ .Values.dynamicConfig.pollInterval | default "10s" | quote }}
+        filepath: {{ $.Values.dynamicconfig.filebased.filepath }}
+        pollInterval: {{ $.Values.dynamicconfig.filebased.pollInterval | default "10s" | quote }}
 
   dynamic_config.yaml: |-
     {{- toYaml .Values.dynamicConfig.values | nindent 12 }}

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -127,6 +127,11 @@ server:
       # WARNING: you **MUST** list the Cadence clusters of a Cadence cluster
       # group in the same order in each configuration to ensure the
       # initialFailoverVersions are synchronized.
+
+      # clusterRedirectionPolicy contains redirection information between cluster components
+      clusterRedirectionPolicy:
+        policy: "selected-apis-forwarding"
+
       clusterInformation:
         - name: cluster-0
           # enabled defines whether the Cadence cluster is enabled.
@@ -370,9 +375,16 @@ web:
 
   affinity: {}
 
-dynamicConfig:
-  values: {}
-  pollInterval: "10s"
+dynamicconfig:
+  client: filebased
+  configstore:
+    pollInterval: "10s"
+    updateRetryAttempts: 2
+    FetchTimeout: "2s"
+    UpdateTimeout: "2s"
+  filebased:
+    filepath: "config/dynamicconfig/development_es.yaml"
+    pollInterval: "10s"
 
 schema:
   setup:
@@ -402,3 +414,11 @@ mysql:
   initializationFiles:
     user.sql: |-
       GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';
+      
+#  Indicates if the tchannel and grpc connections will be enabled
+connectionType:
+  thrift:
+     enabled: true
+  grpc: 
+     enabled: true
+

--- a/cadence/values.yaml
+++ b/cadence/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: ubercadence/server
-    tag: 0.24.0
+    tag: 1.0.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -60,15 +60,6 @@ server:
     # clusterMetadata contains the settings of the Cadence clusters
     # participating in a Cadence cluster group.
     clusterMetadata:
-      # enableGlobalDomain when set to true allows creating global domains which
-      # are replicated between all Cadence clusters distributed among different
-      # Kubernetes clusters and whose tasks are served by the active Cadence
-      # cluster in the replication.
-      #
-      # WARNING: This value **MUST NOT** be changed after launching the first
-      # Cadence cluster of the Cadence cluster group.
-      enableGlobalDomain: true
-
       # maximumClusterCount defines and locks the maximum number of Cadence
       # clusters of a Cadence cluster group at any point in the future included
       # clusters added later.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no/ 
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets |  Z
| License         | Apache 2.0

### What's in this PR?
Adapt cadence chart according to the recently released version 1.0.0. This chart has been named with the same version since it is the first jump to version 1.x.x.
The main changes affect the following elements:
- Dynamic configuration, file type, pooling systems, retries...etc
- Connectors, it's parameterized to include only the bootstrap of the requested services, instead of all the tchannel and grpc services, as well as configuration of the appropriate ports.
- Cluster info: redirection policies.

### Why?
new release of cadence

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

 
