### PR TITLE
[K8s 1.25 Support] Disable PodSecurityPolicy in prometheus operator charts

### DIFF
--- a/prometheus-operator-standalone/Chart.yaml
+++ b/prometheus-operator-standalone/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - operator
 - prometheus
 name: prometheus-operator-standalone
-version: 13.4.0
+version: 13.4.1
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/banzaicloud/banzai-charts

--- a/prometheus-operator-standalone/templates/psp-clusterrole.yaml
+++ b/prometheus-operator-standalone/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pspEnabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,4 +11,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "prometheus-operator.fullname" . }}
-
+{{- end }}

--- a/prometheus-operator-standalone/templates/psp-clusterrolebinding.yaml
+++ b/prometheus-operator-standalone/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pspEnabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/prometheus-operator-standalone/templates/psp.yaml
+++ b/prometheus-operator-standalone/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -46,3 +47,4 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}

--- a/prometheus-operator-standalone/values.yaml
+++ b/prometheus-operator-standalone/values.yaml
@@ -19,7 +19,7 @@ kubeTargetVersionOverride: ""
 fullnameOverride: ""
 
 
-
+pspEnabled: false
 pspAnnotations: {}
 ## Specify pod annotations
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | https://cisco-eti.atlassian.net/browse/CAL-663
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Disable PodSecurityPolicy as it is no longer supported in k8s v1.25+


