### PR TITLE
Thanos termination grace period seconds add

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.9
+version: 0.4.10
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -205,6 +205,7 @@ These values are just samples, for more fine-tuning please check the values.yaml
 | store.serviceAccount | Name of the Kubernetes service account to use | "" |
 | store.livenessProbe  | Set up liveness probe for store available for Thanos v0.8.0+) |  {} |
 | store.readinessProbe  | Set up readinessProbe for store (available for Thanos v0.8.0+) | {}  |
+| store.terminationGracePeriodSeconds | Set up terminationGracePeriodSeconds for store - default in kubernetes is 30 | "" |
 | timePartioning   |  list of min/max time for store partitions. See more details below. Setting this will create mutlipale thanos store deployments based on the number of items in the list  | [{min: "", max: ""}] |
 | hashPartioning.shards   | The number of shared used to partition the blocks based on the hashmod of the blocks. Can not be used with time partitioning | "" |
 | initContainers   |  InitContainers allows injecting specialized containers that run before app containers. This is meant to pre-configure and tune mounted volume permissions.  | [] |
@@ -265,6 +266,7 @@ timePartioning:
 | query.rbac.enabled | Enable RBAC to use the PSP | false |
 | query.livenessProbe | Set up liveness probe for query | {} |
 | query.readinessProbe | Set up readinessProbe for query | {} |
+| query.terminationGracePeriodSeconds | Set up terminationGracePeriodSeconds for query - default in kubernetes is 30 | "" |
 
 ## Rule
 |Name|Description| Default Value|
@@ -356,6 +358,7 @@ timePartioning:
 | queryFrontend.cache.validity | | `` |
 | queryFrontend.log.request.decision | Request Logging for logging the start and end of requests | `LogFinishCall` |
 | queryFrontend.serviceAccountAnnotations | Optional annotations to be added to the ServiceAccount | {} |
+| queryFrontend.terminationGracePeriodSeconds | Set up terminationGracePeriodSeconds for query frontend - default in kubernetes is 30 | "" |
 
 ## Contributing
 Contributions are very welcome!

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -141,6 +141,9 @@ spec:
       {{- with .Values.query.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.query.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with .Values.query.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/query-frontend-deployment.yaml
+++ b/thanos/templates/query-frontend-deployment.yaml
@@ -174,6 +174,9 @@ spec:
       {{- with .Values.queryFrontend.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.queryFrontend.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with .Values.queryFrontend.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -173,6 +173,9 @@ spec:
       {{- with $root.Values.store.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $root.Values.store.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with $root.Values.store.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/thanos/thanos
-  tag: v0.17.1
+  tag: v0.28.1
   pullPolicy: IfNotPresent
 
 store:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Added option to control the terminationGracePeriodSeconds value.


### Why?
Thanos at scale needs more time to handle requests and to close connections gracefully.


### Additional context



### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

