### PR TITLE
Adding container level securityContext for all thanos components

### DIFF
--- a/thanos/Chart.yaml
+++ b/thanos/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.4.9
+version: 0.4.10
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
 - name: Banzai Cloud

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -146,43 +146,44 @@ This section describes the values available
 
 These setting applicable to nearly all components.
 
-|Name|Description| Default Value|
-|----|-----------|--------------|
-| $component.labels | Additional labels to the Pod | {} |
-| $component.annotations | Additional annotations to the Pod | {} |
-| $component.deploymentLabels | Additional labels to the deployment | {} |
-| $component.deploymentAnnotations | Additional annotations to the deployment | {} |
-| $component.extraEnv | Add extra environment variables | [] |
-| $component.strategy | Kubernetes [deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) object | {} |
-| $component.updateStrategy | Kubernetes [statefulset update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) object | {} |
-| $component.metrics.annotations.enabled | Prometheus annotation for component | false |
-| $component.metrics.serviceMonitor.enabled | Prometheus ServiceMonitor definition for component | false |
-| $component.securityContext | SecurityContext for Pod | {} |
-| $component.resources | Resource definition for container | {} |
-| $component.tolerations | [Node tolerations for server scheduling to nodes with taints](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | {} |
-| $component.nodeSelector | [Node labels for compact pod assignment](https://kubernetes.io/docs/user-guide/node-selection/) | {} |
-| $component.affinity | [Pod affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity) | {} |
-| $component.grpc.port | grpc listen port number | 10901 |
-| $component.grpc.service.annotations | Service definition for grpc service | {} |
-| $component.grpc.service.matchLabels | Pod label selector to match grpc service on. | `{}` |
-| $component.grpc.ingress.enabled | Set up ingress for the grpc service | false |
-| $component.grpc.ingress.defaultBackend | Set up default backend for ingress | false |
-| $component.grpc.ingress.annotations | Add annotations to ingress | {} |
-| $component.grpc.ingress.labels | Add labels to ingress | {} |
-| $component.grpc.ingress.path | Ingress path | "/" |
-| $component.grpc.ingress.hosts | Ingress hosts | [] |
-| $component.grpc.ingress.tls | Ingress TLS configuration | [] |
-| $component.http.port | http listen port number | 10902 |
-| $component.http.service.annotations | Service definition for http service | {} |
-| $component.http.service.matchLabels | Pod label selector to match http service on. | `{}` |
-| $component.http.ingress.enabled | Set up ingress for the http service | false |
-| $component.http.ingress.apiVersion | Set API version for ingress | extensions/v1beta1 |
-| $component.http.ingress.defaultBackend | Set up default backend for ingress | false |
-| $component.http.ingress.annotations | Add annotations to ingress | {} |
-| $component.http.ingress.labels | Add labels to ingress | {} |
-| $component.http.ingress.path | Ingress path | "/" |
-| $component.http.ingress.hosts | Ingress hosts | [] |
-| $component.http.ingress.tls | Ingress TLS configuration | [] |
+| Name                                      | Description                                                                                                                               | Default Value|
+|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| $component.labels                         | Additional labels to the Pod                                                                                                              | {} |
+| $component.annotations                    | Additional annotations to the Pod                                                                                                         | {} |
+| $component.deploymentLabels               | Additional labels to the deployment                                                                                                       | {} |
+| $component.deploymentAnnotations          | Additional annotations to the deployment                                                                                                  | {} |
+| $component.extraEnv                       | Add extra environment variables                                                                                                           | [] |
+| $component.strategy                       | Kubernetes [deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) object            | {} |
+| $component.updateStrategy                 | Kubernetes [statefulset update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) object | {} |
+| $component.metrics.annotations.enabled    | Prometheus annotation for component                                                                                                       | false |
+| $component.metrics.serviceMonitor.enabled | Prometheus ServiceMonitor definition for component                                                                                        | false |
+| $component.securityContext                | SecurityContext for Pod                                                                                                                   | {} |
+| $component.containerSecurityContext       | SecurityContext for Container                                                                                                             | {} |
+| $component.resources                      | Resource definition for container                                                                                                         | {} |
+| $component.tolerations                    | [Node tolerations for server scheduling to nodes with taints](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)         | {} |
+| $component.nodeSelector                   | [Node labels for compact pod assignment](https://kubernetes.io/docs/user-guide/node-selection/)                                           | {} |
+| $component.affinity                       | [Pod affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)                                          | {} |
+| $component.grpc.port                      | grpc listen port number                                                                                                                   | 10901 |
+| $component.grpc.service.annotations       | Service definition for grpc service                                                                                                       | {} |
+| $component.grpc.service.matchLabels       | Pod label selector to match grpc service on.                                                                                              | `{}` |
+| $component.grpc.ingress.enabled           | Set up ingress for the grpc service                                                                                                       | false |
+| $component.grpc.ingress.defaultBackend    | Set up default backend for ingress                                                                                                        | false |
+| $component.grpc.ingress.annotations       | Add annotations to ingress                                                                                                                | {} |
+| $component.grpc.ingress.labels            | Add labels to ingress                                                                                                                     | {} |
+| $component.grpc.ingress.path              | Ingress path                                                                                                                              | "/" |
+| $component.grpc.ingress.hosts             | Ingress hosts                                                                                                                             | [] |
+| $component.grpc.ingress.tls               | Ingress TLS configuration                                                                                                                 | [] |
+| $component.http.port                      | http listen port number                                                                                                                   | 10902 |
+| $component.http.service.annotations       | Service definition for http service                                                                                                       | {} |
+| $component.http.service.matchLabels       | Pod label selector to match http service on.                                                                                              | `{}` |
+| $component.http.ingress.enabled           | Set up ingress for the http service                                                                                                       | false |
+| $component.http.ingress.apiVersion        | Set API version for ingress                                                                                                               | extensions/v1beta1 |
+| $component.http.ingress.defaultBackend    | Set up default backend for ingress                                                                                                        | false |
+| $component.http.ingress.annotations       | Add annotations to ingress                                                                                                                | {} |
+| $component.http.ingress.labels            | Add labels to ingress                                                                                                                     | {} |
+| $component.http.ingress.path              | Ingress path                                                                                                                              | "/" |
+| $component.http.ingress.hosts             | Ingress hosts                                                                                                                             | [] |
+| $component.http.ingress.tls               | Ingress TLS configuration                                                                                                                 | [] |
 
 ## Store
 

--- a/thanos/templates/bucket-deployment.yaml
+++ b/thanos/templates/bucket-deployment.yaml
@@ -69,6 +69,7 @@ spec:
             mountPath: /etc/config
             readOnly: true
         resources: {{ toYaml .Values.bucket.resources | nindent 10 }}
+        securityContext: {{ toYaml .Values.bucket.containerSecurityContext | nindent 10 }}
       volumes:
       - name: config-volume
         secret:

--- a/thanos/templates/compact-deployment.yaml
+++ b/thanos/templates/compact-deployment.yaml
@@ -73,6 +73,7 @@ spec:
         - name: data-volume
           mountPath: /var/thanos/compact
         resources: {{ toYaml .Values.compact.resources | nindent 10 }}
+        securityContext: {{ toYaml .Values.compact.containerSecurityContext | nindent 10 }}
       volumes:
       - name: data-volume
       {{- if .Values.compact.dataVolume.backend }}

--- a/thanos/templates/query-deployment.yaml
+++ b/thanos/templates/query-deployment.yaml
@@ -107,6 +107,8 @@ spec:
           containerPort: {{ .Values.query.grpc.port }}
         resources:
           {{ toYaml .Values.query.resources | nindent 10 }}
+        securityContext:
+          { { toYaml .Values.query.containerSecurityContext | nindent 10 } }
         volumeMounts:
         {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
         - mountPath: /etc/query/{{ . }}

--- a/thanos/templates/query-frontend-deployment.yaml
+++ b/thanos/templates/query-frontend-deployment.yaml
@@ -140,6 +140,8 @@ spec:
           containerPort: {{ .Values.queryFrontend.grpc.port }}
         resources:
           {{ toYaml .Values.queryFrontend.resources | nindent 10 }}
+        securityContext:
+          { { toYaml .Values.queryFrontend.containerSecurityContext | nindent 10 } }
         volumeMounts:
         {{- range .Values.queryFrontend.serviceDiscoveryFileConfigMaps }}
         - mountPath: /etc/query-frontend/{{ . }}

--- a/thanos/templates/rule-statefulset.yaml
+++ b/thanos/templates/rule-statefulset.yaml
@@ -44,6 +44,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources: {{ toYaml .Values.rule.resources | nindent 10 }}
+        securityContext: {{ toYaml .Values.rule.containerSecurityContext | nindent 10 }}
         {{- with .Values.rule.extraEnv }}
         env: {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/thanos/templates/store-deployment.yaml
+++ b/thanos/templates/store-deployment.yaml
@@ -145,6 +145,8 @@ spec:
         {{- end }}
         resources:
           {{ toYaml $root.Values.store.resources | nindent 10 }}
+        securityContext:
+          { { toYaml $root.Values.store.containerSecurityContext | nindent 10 } }
       volumes:
       - name: data
       {{- if $root.Values.store.dataVolume.backend }}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -152,6 +152,8 @@ store:
       #      - chart-example.local
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: {}
   resources: {}
   #  limits:
   #    cpu: 2000m
@@ -378,6 +380,8 @@ query:
 
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: { }
   resources: {}
   #  limits:
   #    cpu: 2000m
@@ -597,6 +601,8 @@ queryFrontend:
 
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: { }
   resources: {}
   #  limits:
   #    cpu: 2000m
@@ -713,6 +719,8 @@ compact:
 
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: { }
   resources: {}
   #  limits:
   #    cpu: 2000m
@@ -824,6 +832,8 @@ bucket:
 
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: { }
   resources: {}
   #  limits:
   #    cpu: 2000m
@@ -1056,6 +1066,8 @@ rule:
 
   # Optional securityContext
   securityContext: {}
+  # Optional containerSecurityContext
+  containerSecurityContext: { }
   resources: {}
   #  limits:
   #    cpu: 2000m


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR will enable to create securityContext at the container level for all components of thanos.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently not able to change the securityContext at container level based on https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
